### PR TITLE
Settings page, offline Feeder cfg editor, and install defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,22 @@
 nexus/*.zip
 /target-verify
 /target-alt
+
+# Root release / local build junk
+/dlss5oneclick.exe
+/*.exe
+/*.pdb
+/*.ilk
+/*.dll
+
+# Local diagnostic dumps
+gothic_check*.txt
+
+# IDE / VS
+.vs/
+*.user
+*.suo
+
+# Common local logs
+*.log
+cargo-timing*.html

--- a/src/diagnose.rs
+++ b/src/diagnose.rs
@@ -210,6 +210,13 @@ pub fn diagnose(st: &GameStatus) -> Vec<Finding> {
              in the add-on panel.",
         ));
     } else if st.mode == game::Mode::Native {
+        if st.feeder {
+            out.push(warn(
+                "Mode is Native DLSS (game ships its own DLSS), but dlss5-feed.addon64 is still \
+                 present. Feeder Optimize does not apply here — NR is game/renodx. Run Remove \
+                 (incl. Feeder leftovers) or Install again so Native cleanup drops the Feeder.",
+            ));
+        }
         // The add-on hooks NVSDK_NGX_D3D12_*. A game whose DLSS runs on D3D11
         // calls the D3D11 entry points, which it never sees, so "no create"
         // is expected until the bridge is installed (#33, BG3 DX11).

--- a/src/feeder_cfg.rs
+++ b/src/feeder_cfg.rs
@@ -1,0 +1,290 @@
+//! Offline read/write of `dlss5-feed.cfg` + `DLSS5_Feed.fx` uniforms in ReShadePreset.ini.
+
+use crate::quality_preset;
+use crate::reshade_ini::{self, Ini};
+use anyhow::{bail, Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const CFG_NAME: &str = "dlss5-feed.cfg";
+
+/// Editable Feeder knobs + FX residual masks — what the Setup panel shows.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FeederKnobs {
+    pub work_resolution: i32,
+    pub work_upscale: i32,
+    pub work_sharpness: f32,
+    pub ofa_enabled: bool,
+    pub ofa_grid: i32,
+    pub ofa_perf: i32,
+    pub reset_mode: i32,
+    pub light_stab: bool,
+    pub light_stab_strength: f32,
+    pub engine_velocity: bool,
+    pub evaluate_stride: i32,
+    pub log_detail: i32,
+    pub appearance_mask: bool,
+    pub lighting_mask: bool,
+    pub detail_mask: bool,
+    pub appearance_threshold: f32,
+    pub lighting_threshold: f32,
+    pub detail_threshold: f32,
+    pub auto_profile: String,
+}
+
+impl Default for FeederKnobs {
+    fn default() -> Self {
+        Self {
+            work_resolution: 100,
+            work_upscale: 0,
+            work_sharpness: 0.30,
+            ofa_enabled: false,
+            ofa_grid: 2,
+            ofa_perf: 15,
+            reset_mode: 2,
+            light_stab: false,
+            light_stab_strength: 0.35,
+            engine_velocity: true,
+            evaluate_stride: 1,
+            log_detail: 1,
+            appearance_mask: true,
+            lighting_mask: true,
+            detail_mask: true,
+            appearance_threshold: 0.040,
+            lighting_threshold: 0.050,
+            detail_threshold: 0.022,
+            auto_profile: String::new(),
+        }
+    }
+}
+
+impl FeederKnobs {
+    /// Axes used for nearest-neighbor FPS lookup (normalized 0..1 later).
+    #[allow(dead_code)]
+    pub fn knobs_vec(&self) -> [f32; 6] {
+        [
+            self.work_resolution as f32 / 100.0,
+            if self.ofa_enabled { 1.0 } else { 0.0 },
+            self.ofa_grid as f32 / 4.0,
+            self.reset_mode as f32 / 2.0,
+            if self.light_stab { 1.0 } else { 0.0 },
+            self.evaluate_stride as f32 / 4.0,
+        ]
+    }
+}
+
+pub fn cfg_path(game_dir: &Path) -> PathBuf {
+    game_dir.join(CFG_NAME)
+}
+
+#[allow(dead_code)]
+pub fn exists(game_dir: &Path) -> bool {
+    cfg_path(game_dir).is_file()
+}
+
+fn parse_kv(text: &str) -> Vec<(String, String)> {
+    text.lines()
+        .filter_map(|l| {
+            let s = l.trim();
+            if s.is_empty() || s.starts_with('#') || s.starts_with(';') {
+                return None;
+            }
+            let (k, v) = s.split_once('=')?;
+            Some((k.trim().to_owned(), v.trim().to_owned()))
+        })
+        .collect()
+}
+
+fn get_i(map: &[(String, String)], key: &str, default: i32) -> i32 {
+    map.iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(key))
+        .and_then(|(_, v)| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn get_f(map: &[(String, String)], key: &str, default: f32) -> f32 {
+    map.iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(key))
+        .and_then(|(_, v)| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn get_s(map: &[(String, String)], key: &str) -> String {
+    map.iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(key))
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default()
+}
+
+fn fx_f(ini: &Ini, key: &str, default: f32) -> f32 {
+    ini.get("DLSS5_Feed.fx", key)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn fx_b(ini: &Ini, key: &str, default: bool) -> bool {
+    match ini.get("DLSS5_Feed.fx", key) {
+        Some(v) => v == "1" || v.eq_ignore_ascii_case("true"),
+        None => default,
+    }
+}
+
+/// Load knobs from disk. Err when cfg is missing.
+pub fn load(game_dir: &Path) -> Result<FeederKnobs> {
+    let path = cfg_path(game_dir);
+    if !path.is_file() {
+        bail!("not installed: {} missing", CFG_NAME);
+    }
+    let text = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let kv = parse_kv(&text);
+    let preset = Ini::load(&game_dir.join("ReShadePreset.ini"));
+    let mut k = FeederKnobs::default();
+    k.work_resolution = get_i(&kv, "work_resolution", k.work_resolution).clamp(50, 100);
+    k.work_upscale = get_i(&kv, "work_upscale", k.work_upscale);
+    k.work_sharpness = get_f(&kv, "work_sharpness", k.work_sharpness);
+    k.ofa_enabled = get_i(&kv, "ofa_enabled", 0) != 0;
+    k.ofa_grid = get_i(&kv, "ofa_grid", k.ofa_grid);
+    k.ofa_perf = get_i(&kv, "ofa_perf", k.ofa_perf);
+    k.reset_mode = get_i(&kv, "reset_mode", k.reset_mode);
+    k.light_stab = get_i(&kv, "light_stab", 0) != 0;
+    k.light_stab_strength = get_f(&kv, "light_stab_strength", k.light_stab_strength);
+    k.engine_velocity = get_i(&kv, "engine_velocity", 1) != 0;
+    k.evaluate_stride = get_i(&kv, "evaluate_stride", k.evaluate_stride).clamp(1, 4);
+    k.log_detail = get_i(&kv, "log_detail", k.log_detail);
+    k.auto_profile = get_s(&kv, "auto_profile");
+    k.appearance_mask = fx_b(&preset, "APPEARANCE_MASK", k.appearance_mask);
+    k.lighting_mask = fx_b(&preset, "LIGHTING_MASK", k.lighting_mask);
+    k.detail_mask = fx_b(&preset, "DETAIL_MASK", k.detail_mask);
+    k.appearance_threshold = fx_f(&preset, "APPEARANCE_THRESHOLD", k.appearance_threshold);
+    k.lighting_threshold = fx_f(&preset, "LIGHTING_THRESHOLD", k.lighting_threshold);
+    k.detail_threshold = fx_f(&preset, "DETAIL_THRESHOLD", k.detail_threshold);
+    Ok(k)
+}
+
+fn set_line(lines: &mut Vec<String>, key: &str, value: String) {
+    let prefix = format!("{key}=");
+    if let Some(i) = lines
+        .iter()
+        .position(|l| l.to_ascii_lowercase().starts_with(&prefix.to_ascii_lowercase()))
+    {
+        lines[i] = format!("{key}={value}");
+    } else {
+        lines.push(format!("{key}={value}"));
+    }
+}
+
+/// Write knobs back to cfg + FX uniforms. Feeder re-reads cfg ~every 60 frames.
+pub fn save(game_dir: &Path, k: &FeederKnobs) -> Result<()> {
+    let path = cfg_path(game_dir);
+    let prev = if path.is_file() {
+        fs::read_to_string(&path)?
+    } else {
+        // Seed a full cfg from medium defaults so Feeder has every key.
+        let r = quality_preset::fallback_medium();
+        quality_preset::feeder_cfg_text(&r)
+    };
+    let mut lines: Vec<String> = prev.lines().map(|l| l.to_string()).collect();
+    set_line(&mut lines, "work_resolution", k.work_resolution.clamp(50, 100).to_string());
+    set_line(&mut lines, "work_upscale", k.work_upscale.to_string());
+    set_line(
+        &mut lines,
+        "work_sharpness",
+        format!("{:.2}", k.work_sharpness),
+    );
+    set_line(
+        &mut lines,
+        "ofa_enabled",
+        (k.ofa_enabled as i32).to_string(),
+    );
+    set_line(&mut lines, "ofa_grid", k.ofa_grid.to_string());
+    set_line(&mut lines, "ofa_perf", k.ofa_perf.to_string());
+    set_line(&mut lines, "reset_mode", k.reset_mode.to_string());
+    set_line(
+        &mut lines,
+        "reset_every",
+        if k.reset_mode == 1 { "1" } else { "0" }.into(),
+    );
+    set_line(&mut lines, "light_stab", (k.light_stab as i32).to_string());
+    set_line(
+        &mut lines,
+        "light_stab_strength",
+        format!("{:.3}", k.light_stab_strength),
+    );
+    set_line(
+        &mut lines,
+        "engine_velocity",
+        (k.engine_velocity as i32).to_string(),
+    );
+    set_line(
+        &mut lines,
+        "evaluate_stride",
+        k.evaluate_stride.clamp(1, 4).to_string(),
+    );
+    set_line(&mut lines, "log_detail", k.log_detail.to_string());
+    // Manual edit → mark custom so auto-profile does not fight the user.
+    set_line(&mut lines, "quality_preset", "custom".into());
+    set_line(&mut lines, "auto_profile_applied", "1".into());
+    let mut out = lines.join("\n");
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    fs::write(&path, out).with_context(|| format!("write {}", path.display()))?;
+
+    let fx = vec![
+        (
+            "APPEARANCE_MASK",
+            if k.appearance_mask { "1" } else { "0" }.into(),
+        ),
+        (
+            "APPEARANCE_THRESHOLD",
+            format!("{:.3}", k.appearance_threshold),
+        ),
+        (
+            "LIGHTING_MASK",
+            if k.lighting_mask { "1" } else { "0" }.into(),
+        ),
+        (
+            "LIGHTING_THRESHOLD",
+            format!("{:.3}", k.lighting_threshold),
+        ),
+        (
+            "DETAIL_MASK",
+            if k.detail_mask { "1" } else { "0" }.into(),
+        ),
+        ("DETAIL_THRESHOLD", format!("{:.3}", k.detail_threshold)),
+    ];
+    reshade_ini::write_feed_fx_uniforms(game_dir, &fx)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn roundtrip_cfg() {
+        let t = tempdir().unwrap();
+        let d = t.path();
+        let k = FeederKnobs {
+            work_resolution: 85,
+            ofa_enabled: true,
+            reset_mode: 1,
+            appearance_threshold: 0.033,
+            ..Default::default()
+        };
+        save(d, &k).unwrap();
+        assert!(exists(d));
+        let back = load(d).unwrap();
+        assert_eq!(back.work_resolution, 85);
+        assert!(back.ofa_enabled);
+        assert_eq!(back.reset_mode, 1);
+        assert!((back.appearance_threshold - 0.033).abs() < 0.001);
+    }
+
+    #[test]
+    fn missing_cfg_errors() {
+        let t = tempdir().unwrap();
+        assert!(load(t.path()).is_err());
+    }
+}

--- a/src/feeder_cfg.rs
+++ b/src/feeder_cfg.rs
@@ -33,6 +33,7 @@ pub struct FeederKnobs {
 }
 
 impl Default for FeederKnobs {
+    /// Match Feeder stock (`g_cfg` + OFA/velocity/lightstab/diag + FX shader defaults).
     fn default() -> Self {
         Self {
             work_resolution: 100,
@@ -40,7 +41,7 @@ impl Default for FeederKnobs {
             work_sharpness: 0.30,
             ofa_enabled: false,
             ofa_grid: 2,
-            ofa_perf: 15,
+            ofa_perf: 10, // feed_ofa.h: { enabled=0, grid=2, perf=10 }
             reset_mode: 2,
             light_stab: false,
             light_stab_strength: 0.35,
@@ -50,9 +51,10 @@ impl Default for FeederKnobs {
             appearance_mask: true,
             lighting_mask: true,
             detail_mask: true,
-            appearance_threshold: 0.040,
-            lighting_threshold: 0.050,
-            detail_threshold: 0.022,
+            // DLSS5_Feed.fx uniform defaults
+            appearance_threshold: 0.035,
+            lighting_threshold: 0.040,
+            detail_threshold: 0.018,
             auto_profile: String::new(),
         }
     }
@@ -163,10 +165,10 @@ pub fn load(game_dir: &Path) -> Result<FeederKnobs> {
 
 fn set_line(lines: &mut Vec<String>, key: &str, value: String) {
     let prefix = format!("{key}=");
-    if let Some(i) = lines
-        .iter()
-        .position(|l| l.to_ascii_lowercase().starts_with(&prefix.to_ascii_lowercase()))
-    {
+    if let Some(i) = lines.iter().position(|l| {
+        l.to_ascii_lowercase()
+            .starts_with(&prefix.to_ascii_lowercase())
+    }) {
         lines[i] = format!("{key}={value}");
     } else {
         lines.push(format!("{key}={value}"));
@@ -184,7 +186,11 @@ pub fn save(game_dir: &Path, k: &FeederKnobs) -> Result<()> {
         quality_preset::feeder_cfg_text(&r)
     };
     let mut lines: Vec<String> = prev.lines().map(|l| l.to_string()).collect();
-    set_line(&mut lines, "work_resolution", k.work_resolution.clamp(50, 100).to_string());
+    set_line(
+        &mut lines,
+        "work_resolution",
+        k.work_resolution.clamp(50, 100).to_string(),
+    );
     set_line(&mut lines, "work_upscale", k.work_upscale.to_string());
     set_line(
         &mut lines,
@@ -243,14 +249,8 @@ pub fn save(game_dir: &Path, k: &FeederKnobs) -> Result<()> {
             "LIGHTING_MASK",
             if k.lighting_mask { "1" } else { "0" }.into(),
         ),
-        (
-            "LIGHTING_THRESHOLD",
-            format!("{:.3}", k.lighting_threshold),
-        ),
-        (
-            "DETAIL_MASK",
-            if k.detail_mask { "1" } else { "0" }.into(),
-        ),
+        ("LIGHTING_THRESHOLD", format!("{:.3}", k.lighting_threshold)),
+        ("DETAIL_MASK", if k.detail_mask { "1" } else { "0" }.into()),
         ("DETAIL_THRESHOLD", format!("{:.3}", k.detail_threshold)),
     ];
     reshade_ini::write_feed_fx_uniforms(game_dir, &fx)?;

--- a/src/game.rs
+++ b/src/game.rs
@@ -1201,9 +1201,7 @@ pub fn install_folder_mismatch(preferred_exe: &Path) -> Option<String> {
     let mut cur = ship_dir.parent();
     for _ in 0..4 {
         let Some(d) = cur else { break };
-        if (d.join(RESHADE_PROXY).is_file() || d.join(FEEDER_MARKER).is_file())
-            && d != ship_dir
-        {
+        if (d.join(RESHADE_PROXY).is_file() || d.join(FEEDER_MARKER).is_file()) && d != ship_dir {
             return Some(format!(
                 "ReShade/Feeder found in {} but not next to {} — Install on the Shipping exe",
                 d.display(),
@@ -1814,14 +1812,21 @@ mod tests {
         std::env::set_var("DLSS5ONECLICK_SKIP_GPU_CHECK", "1");
         let st = inspect(&exe).unwrap();
         assert_eq!(st.api, Api::Dx9);
-        assert!(st.needs_dgvoodoo(), "DX9 without dgVoodoo should need the install step");
+        assert!(
+            st.needs_dgvoodoo(),
+            "DX9 without dgVoodoo should need the install step"
+        );
         assert!(
             !st.problems.iter().any(|p| p.contains("DirectX 9")),
             "DX9 without dgVoodoo must not hard-block Install: {:?}",
             st.problems
         );
 
-        fs::write(d.join("dgVoodoo.conf"), b"[General]\nOutputAPI = bestavailable\n").unwrap();
+        fs::write(
+            d.join("dgVoodoo.conf"),
+            b"[General]\nOutputAPI = bestavailable\n",
+        )
+        .unwrap();
         let st = inspect(&exe).unwrap();
         assert_eq!(st.api, Api::Dx9);
         assert!(!st.needs_dgvoodoo());
@@ -1840,7 +1845,11 @@ mod tests {
             return;
         }
         std::env::set_var("DLSS5ONECLICK_SKIP_GPU_CHECK", "1");
-        assert_eq!(detect_api(exe), Api::Dx9, "Gothic3.exe must classify as DX9");
+        assert_eq!(
+            detect_api(exe),
+            Api::Dx9,
+            "Gothic3.exe must classify as DX9"
+        );
         assert_eq!(detect_api(exe).label(), "DX9");
         let st = inspect(exe).unwrap();
         assert_eq!(st.api, Api::Dx9);
@@ -1884,7 +1893,11 @@ mod tests {
         let t = tempfile::tempdir().unwrap();
         let d = t.path();
         assert!(!is_dgvoodoo(d));
-        fs::write(d.join("dgVoodoo.conf"), b"[General]\nOutputAPI = bestavailable\n").unwrap();
+        fs::write(
+            d.join("dgVoodoo.conf"),
+            b"[General]\nOutputAPI = bestavailable\n",
+        )
+        .unwrap();
         assert!(is_dgvoodoo(d));
     }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -115,32 +115,34 @@ pub enum Mode {
 /// Graphics API the exe imports, from its PE import table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Api {
+    /// Direct3D 9. DLSS 5 needs a D3D11/12 device; the supported path is
+    /// dgVoodoo2 translating D3D9 to D3D11 so this tool's `dxgi.dll` ReShade
+    /// can load (verified on Dead or Alive 5 Last Round, #17, #37). Install
+    /// downloads official dgVoodoo 2.87.3 into the game folder when missing.
+    /// Aion loads system d3d9.dll by name (#16) so local ReShade d3d9.dll hooks it.
+    Dx9,
     /// Direct3D 10/10.1. The 32-bit Feeder add-on runs these natively from
     /// 0.13.1-beta.1 (a private D3D11 relay device inside the game process);
     /// a game imports `d3d10_1.dll` rather than `d3d10.dll` in practice.
     Dx10,
     Dx11,
     Dx12,
-    /// Imports `d3d9.dll` and no newer Direct3D. DLSS needs a D3D11/12 device,
-    /// so these need dgVoodoo2 in front before anything here applies -- and the
-    /// system d3d9.dll is loaded by name, so a local ReShade d3d9.dll is what
-    /// hooks it, never the dxgi.dll this tool installs (#16, Aion).
-    Dx9,
     /// Imports `vulkan-1.dll` and no Direct3D. ReShade reaches a Vulkan game
     /// through a registered Vulkan layer, not through a `dxgi.dll` beside the
     /// exe, so this install has nothing to load (#6, Detroit: Become Human).
     Vulkan,
-    /// Neither d3d11.dll nor d3d12.dll is a static import (loaded at runtime, or DX9/Vulkan).
+    /// No static D3D/Vulkan import (loaded at runtime). Treated like DX12 for
+    /// the install plan; DX9 is classified separately when `d3d9.dll` is imported.
     Unknown,
 }
 
 impl Api {
     pub fn label(self) -> &'static str {
         match self {
+            Api::Dx9 => "DX9",
             Api::Dx10 => "DX10",
             Api::Dx11 => "DX11",
             Api::Dx12 => "DX12",
-            Api::Dx9 => "DX9",
             Api::Vulkan => "Vulkan",
             Api::Unknown => "API unknown, assuming DX12",
         }
@@ -332,8 +334,8 @@ pub fn pe_imports(exe: &Path) -> Vec<String> {
 }
 
 /// Which D3D a static import table implies. `d3d10_1.dll` is what a Direct3D
-/// 10 game actually imports; the upstream installer looked only for
-/// `d3d10.dll` and mistook such games for DirectX 9.
+/// 10 game actually imports (often alongside `d3d9.dll`); higher APIs win so
+/// those are not misclassified as DirectX 9.
 fn classify_imports(imports: &[String]) -> Api {
     let has = |n: &str| imports.iter().any(|i| i == n);
     if has("d3d12.dll") {
@@ -473,9 +475,30 @@ pub fn is_dgvoodoo(game_dir: &Path) -> bool {
     }
     let dll = game_dir.join("d3d9.dll");
     match fs::read(&dll) {
-        Ok(b) => b.windows(8).any(|w| w.eq_ignore_ascii_case(b"dgVoodoo")),
+        Ok(b) => dll_mentions_dgvoodoo(&b),
         Err(_) => false,
     }
+}
+
+/// Official dgVoodoo builds embed the product name as UTF-16LE in the PE
+/// resources; older / debug builds may use ASCII. Either counts.
+fn dll_mentions_dgvoodoo(b: &[u8]) -> bool {
+    const NEEDLE: &[u8] = b"dgVoodoo";
+    if b.windows(NEEDLE.len())
+        .any(|w| w.eq_ignore_ascii_case(NEEDLE))
+    {
+        return true;
+    }
+    let n = NEEDLE.len() * 2;
+    if b.len() < n {
+        return false;
+    }
+    b.windows(n).any(|w| {
+        NEEDLE
+            .iter()
+            .enumerate()
+            .all(|(i, &c)| w[i * 2].eq_ignore_ascii_case(&c) && w[i * 2 + 1] == 0)
+    })
 }
 
 /// Anti-cheat present in the install tree, by the files those systems ship.
@@ -599,6 +622,117 @@ pub fn game_ships_dlss(game_dir: &Path) -> bool {
     }
 }
 
+/// Unreal-style layout: `…/Binaries/Win64` or a `-Shipping.exe` next to UE folders.
+pub fn unreal_likely(exe: &Path, game_dir: &Path) -> bool {
+    let stem = exe
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if stem.contains("-shipping") || stem.ends_with("shipping") {
+        return true;
+    }
+    if game_dir
+        .parent()
+        .and_then(|b| b.file_name())
+        .is_some_and(|n| n.eq_ignore_ascii_case("binaries"))
+    {
+        return true;
+    }
+    let proj = game_dir
+        .parent()
+        .filter(|b| {
+            b.file_name()
+                .is_some_and(|n| n.eq_ignore_ascii_case("binaries"))
+        })
+        .and_then(|b| b.parent());
+    if let Some(proj) = proj {
+        if proj.join("Plugins").is_dir() || proj.join("Content").is_dir() {
+            return true;
+        }
+    }
+    false
+}
+
+/// UnityPlayer.dll beside the exe (or one folder up for some layouts).
+pub fn unity_likely(game_dir: &Path) -> bool {
+    game_dir.join("UnityPlayer.dll").is_file()
+        || game_dir
+            .parent()
+            .is_some_and(|p| p.join("UnityPlayer.dll").is_file())
+}
+
+/// Lightweight install-time RT / ray-reconstruction hints (not a DXR hook).
+/// Looks for known ini keys, folder names, and `nvngx_dlssd.dll`.
+pub fn rt_likely(game_dir: &Path) -> bool {
+    fn name_hit(n: &str) -> bool {
+        let n = n.to_ascii_lowercase();
+        n.contains("raytracing")
+            || n.contains("ray_tracing")
+            || n.contains("rtxgi")
+            || n.contains("dlssd")
+            || n == "nvngx_dlssd.dll"
+            || n.contains("lumen") && n.contains("hardware")
+    }
+    fn walk_names(d: &Path, depth: u8) -> bool {
+        let Ok(rd) = fs::read_dir(d) else {
+            return false;
+        };
+        for e in rd.flatten() {
+            let p = e.path();
+            let n = p
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_ascii_lowercase();
+            if name_hit(&n) {
+                return true;
+            }
+            if p.is_file()
+                && (n.ends_with(".ini") || n.ends_with(".cfg") || n.ends_with(".txt"))
+                && file_mentions_rt(&p)
+            {
+                return true;
+            }
+            if depth > 0 && p.is_dir() && !n.starts_with('.') && walk_names(&p, depth - 1) {
+                return true;
+            }
+        }
+        false
+    }
+    fn file_mentions_rt(p: &Path) -> bool {
+        let Ok(s) = fs::read_to_string(p) else {
+            return false;
+        };
+        // Cap read cost: only scan first ~64 KiB worth of UTF-8 lossy via take on chars.
+        let head: String = s.chars().take(64 * 1024).collect();
+        let l = head.to_ascii_lowercase();
+        l.contains("hardwareraytracing")
+            || l.contains("r.raytracing")
+            || l.contains("raytracing=")
+            || l.contains("ray tracing")
+            || l.contains("dlss-rr")
+            || l.contains("rayreconstruction")
+    }
+    if walk_names(game_dir, 3) {
+        return true;
+    }
+    // Unreal Plugins tree
+    if let Some(proj) = game_dir
+        .parent()
+        .filter(|b| {
+            b.file_name()
+                .is_some_and(|n| n.eq_ignore_ascii_case("binaries"))
+        })
+        .and_then(Path::parent)
+    {
+        if walk_names(&proj.join("Plugins"), 5) {
+            return true;
+        }
+    }
+    false
+}
+
 #[derive(Debug, Clone)]
 pub struct GameStatus {
     pub mode: Mode,
@@ -625,6 +759,12 @@ pub struct GameStatus {
     pub reframework: bool,
     /// matiasLombo's neural-upstream add-on is in the folder.
     pub upstream: bool,
+    /// Unreal-style layout / Shipping exe (heuristic).
+    pub unreal_likely: bool,
+    /// UnityPlayer.dll present (heuristic).
+    pub unity_likely: bool,
+    /// RT / DLSS-D / raytracing markers on disk (heuristic — not live DXR state).
+    pub rt_likely: bool,
     /// RenoDX game mod this tool installed, from its manifest.
     pub renodx_mod: Option<String>,
     /// Other RenoDX game mods found in the folder (not ours, not the DLSS 5 add-on).
@@ -691,6 +831,10 @@ impl GameStatus {
 
     pub fn is32(&self) -> bool {
         self.bitness == 32
+    }
+    /// DX9 without dgVoodoo2 yet: Install will download it into the game folder.
+    pub fn needs_dgvoodoo(&self) -> bool {
+        self.api == Api::Dx9 && !is_dgvoodoo(self.game_dir())
     }
     /// Where the DLSS 5 add-on and the NVIDIA DLLs live: beside the exe for a
     /// 64-bit game, in `host64\` for a 32-bit one.
@@ -762,30 +906,14 @@ pub fn inspect(exe: &Path) -> Result<GameStatus> {
     // Feeder (verified working on Dead or Alive 5 Last Round, #17).
     if d.join("d3d9.dll").is_file() && !d.join(RESHADE_PROXY).is_file() && !is_dgvoodoo(d) {
         problems.push(
-            "A d3d9.dll proxy is present that is not dgVoodoo2. DirectX 9 itself is not a dead              end -- DLSS 5 needs a D3D11/12 device, and dgVoodoo2 provides one, which is how a              D3D9 game can work here (#17, #37) -- but this tool cannot install behind another              wrapper. Replace it with dgVoodoo 2.87.3 (MS\\x86\\D3D9.dll plus dgVoodoo.conf,              OutputAPI = bestavailable) and run Install again."
+            "A d3d9.dll proxy is present that is not dgVoodoo2. DirectX 9 itself is not a dead              end -- DLSS 5 needs a D3D11/12 device, and dgVoodoo2 provides one, which is how a              D3D9 game can work here (#17, #37) -- but this tool cannot install behind another              wrapper. Replace it with dgVoodoo 2.87.3 (MS\\x86 or MS\\x64\\D3D9.dll plus              dgVoodoo.conf, OutputAPI = d3d11_fl11_0, VRAM >= 4096) and run Install again."
                 .into(),
         );
     }
-    let mut api = detect_api(exe);
-    // dgVoodoo2 is the route this tool tells D3D9 users to take: it presents the
-    // game as D3D11, which is what ReShade and the Feeder then attach to. Once it
-    // is in place the game is a D3D11 game at run time, so refusing it here left
-    // people who had followed the instructions with nowhere to go (Spore, #56).
-    if api == Api::Dx9 && is_dgvoodoo(d) {
-        api = Api::Dx11;
-    }
-    if api == Api::Dx9 {
-        problems.push(
-            "This is a DirectX 9 game. DLSS needs a Direct3D 11 or 12 device, which D3D9 \
-             never creates, so nothing here can attach to it as it stands -- and the game \
-             loads the system d3d9.dll by name, so the dxgi.dll this tool installs is never \
-             even asked for (no ReShade overlay, no ReShade.log). The route that works is \
-             dgVoodoo 2.87.3 first: it turns D3D9 into D3D11, and everything else follows \
-             from there. Put its D3D9.dll from the MS/x86 folder beside the exe with \
-             OutputAPI = bestavailable, confirm the game still starts, then run Install again."
-                .into(),
-        );
-    }
+    let api = detect_api(exe);
+    // Plain D3D9 (Gothic 3, Aion, etc.): ReShade is dxgi.dll here, which a
+    // D3D9 process never loads. Install adds official dgVoodoo 2.87.3 so DX9
+    // is not a hard refuse. A foreign non-dgVoodoo d3d9.dll still blocks above.
     let is32 = bitness == 32;
     if is32 && api == Api::Dx12 {
         problems.push(
@@ -841,6 +969,9 @@ pub fn inspect(exe: &Path) -> Result<GameStatus> {
         host_reshade: is32 && is_reshade_dll(&cdir.join(RESHADE_PROXY)),
         re_engine: d.join(RE_ENGINE_PAK).is_file(),
         reframework: d.join(REFRAMEWORK_DLL).is_file(),
+        unreal_likely: unreal_likely(exe, d),
+        unity_likely: unity_likely(d),
+        rt_likely: rt_likely(d),
         renodx_mod: renodx_mod.clone(),
         foreign_renodx: crate::renodx::foreign_mods(d, renodx_mod.as_deref()),
         anticheat,
@@ -989,10 +1120,124 @@ pub fn find_game_exes(dir: &Path) -> Vec<PathBuf> {
 }
 
 /// Accepts either a game exe or a game folder; returns the exe to use plus
-/// every candidate found (empty when the input was already an exe).
-/// Did this tool install into this folder? True when any marker or manifest
-/// it writes is present. Used to group those games together (#nn) and to
-/// decide whether a component may be refreshed.
+/// every candidate found.
+///
+/// When the input is a **file** (e.g. a 500 KB Unreal bootstrapper next to a
+/// `Game\Binaries\Win64\*-Shipping.exe`), we still search the parent tree so
+/// Install lands next to the real game — not the launcher (Ghostrunner).
+pub fn resolve_target(input: &Path) -> Result<(PathBuf, Vec<PathBuf>)> {
+    if input.is_file() {
+        let mut search_roots: Vec<PathBuf> = Vec::new();
+        if let Some(parent) = input.parent() {
+            search_roots.push(parent.to_path_buf());
+            // Unreal: …/Ghostrunner/Ghostrunner.exe → search parent (and grandparent
+            // when Shipping lives under a same-named subfolder one level up).
+            if let Some(grand) = parent.parent() {
+                search_roots.push(grand.to_path_buf());
+            }
+        }
+        let mut cands: Vec<PathBuf> = Vec::new();
+        for root in &search_roots {
+            for e in find_game_exes(root) {
+                if !cands.iter().any(|c| c == &e) {
+                    cands.push(e);
+                }
+            }
+        }
+        if cands.is_empty() {
+            // Fall back: the file itself (may be the only PE).
+            return Ok((input.to_path_buf(), Vec::new()));
+        }
+        // Re-rank across roots: Shipping first, then 64-bit, then size.
+        cands = rank_exe_candidates(cands);
+        let best = cands[0].clone();
+        return Ok((best, cands));
+    }
+    if input.is_dir() {
+        let c = find_game_exes(input);
+        return match c.first() {
+            Some(first) => Ok((first.clone(), c)),
+            None => bail!("no 64-bit game executable found in {}", input.display()),
+        };
+    }
+    bail!("not found: {}", input.display())
+}
+
+fn rank_exe_candidates(found: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut scored: Vec<(i64, PathBuf)> = found
+        .into_iter()
+        .filter_map(|p| {
+            let stem = p.file_stem()?.to_str()?.to_ascii_lowercase();
+            if is_helper_name(&stem) {
+                return None;
+            }
+            let bits = exe_bitness(&p).ok()?;
+            // Keep 32-bit DX9 titles; prefer 64-bit when both exist.
+            let size = fs::metadata(&p).map(|m| m.len()).unwrap_or(0) as i64;
+            let mut score: i64 = 0;
+            if stem.ends_with("-shipping") {
+                score += 2_000_000_000;
+            }
+            if bits == 64 {
+                score += 500_000_000;
+            }
+            score += size.min(400_000_000);
+            Some((score, p))
+        })
+        .collect();
+    scored.sort_by_key(|s| std::cmp::Reverse(s.0));
+    scored.into_iter().map(|(_, p)| p).collect()
+}
+
+/// True when ReShade/Feeder markers sit on a launcher folder but the preferred
+/// Shipping exe's directory has neither — classic wrong-folder Install.
+pub fn install_folder_mismatch(preferred_exe: &Path) -> Option<String> {
+    let ship_dir = preferred_exe.parent()?;
+    let ship_ok = ship_dir.join(RESHADE_PROXY).is_file() || ship_dir.join(FEEDER_ADDON).is_file();
+    if ship_ok {
+        return None;
+    }
+    // Walk up looking for a sibling/parent that has our install but is not ship_dir.
+    let mut cur = ship_dir.parent();
+    for _ in 0..4 {
+        let Some(d) = cur else { break };
+        if (d.join(RESHADE_PROXY).is_file() || d.join(FEEDER_MARKER).is_file())
+            && d != ship_dir
+        {
+            return Some(format!(
+                "ReShade/Feeder found in {} but not next to {} — Install on the Shipping exe",
+                d.display(),
+                preferred_exe
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("game.exe")
+            ));
+        }
+        cur = d.parent();
+    }
+    None
+}
+
+/// True when EffectSearchPaths point at a missing/empty Shaders folder.
+pub fn shaders_missing(game_dir: &Path) -> bool {
+    let sh = game_dir.join("reshade-shaders").join("Shaders");
+    if !sh.is_dir() {
+        return game_dir.join(RESHADE_PROXY).is_file();
+    }
+    fs::read_dir(&sh)
+        .ok()
+        .map(|rd| {
+            !rd.flatten().any(|e| {
+                e.path()
+                    .extension()
+                    .is_some_and(|x| x.eq_ignore_ascii_case("fx"))
+            })
+        })
+        .unwrap_or(true)
+        && game_dir.join(RESHADE_PROXY).is_file()
+}
+
+/// Sidecar markers this tool leaves so Install / Update / Remove know the folder.
 pub fn installed_by_tool(dir: &Path) -> bool {
     [
         OPTI_MANIFEST,
@@ -1005,20 +1250,6 @@ pub fn installed_by_tool(dir: &Path) -> bool {
     ]
     .iter()
     .any(|m| dir.join(m).is_file())
-}
-
-pub fn resolve_target(input: &Path) -> Result<(PathBuf, Vec<PathBuf>)> {
-    if input.is_file() {
-        return Ok((input.to_path_buf(), Vec::new()));
-    }
-    if input.is_dir() {
-        let c = find_game_exes(input);
-        return match c.first() {
-            Some(first) => Ok((first.clone(), c)),
-            None => bail!("no game executable found in {}", input.display()),
-        };
-    }
-    bail!("not found: {}", input.display())
 }
 
 #[cfg(test)]
@@ -1104,6 +1335,67 @@ pub mod testutil {
         img[sh + 20..sh + 24].copy_from_slice(&(SEC as u32).to_le_bytes()); // PointerToRawData
         img.extend_from_slice(&blob);
         fs::write(path, &img).unwrap();
+        path.to_path_buf()
+    }
+
+    /// Minimal PE with a real import directory so `pe_imports` / `detect_api`
+    /// can see sibling engine DLLs the way Gothic 3 does (exe → Engine.dll → d3d9).
+    pub fn make_pe_with_imports(path: &Path, machine: u16, dlls: &[&str]) -> PathBuf {
+        let pe32 = machine == PE_X86;
+        let opt_magic: u16 = if pe32 { 0x10B } else { 0x20B };
+        // Standard optional header sizes including 16 data directories.
+        let opt_size: u16 = if pe32 { 224 } else { 240 };
+        let sect_raw = 0x400usize;
+        let sect_va = 0x1000usize;
+
+        let mut names_blob = Vec::new();
+        let mut name_rvas = Vec::new();
+        // Descriptors first (20 bytes each + null), then the DLL name strings.
+        let desc_bytes = (dlls.len() + 1) * 20;
+        for dll in dlls {
+            name_rvas.push(sect_va + desc_bytes + names_blob.len());
+            names_blob.extend_from_slice(dll.as_bytes());
+            names_blob.push(0);
+        }
+        let mut idata = vec![0u8; desc_bytes];
+        for (i, &rva) in name_rvas.iter().enumerate() {
+            let off = i * 20;
+            idata[off + 12..off + 16].copy_from_slice(&(rva as u32).to_le_bytes());
+        }
+        idata.extend_from_slice(&names_blob);
+        while !idata.len().is_multiple_of(16) {
+            idata.push(0);
+        }
+
+        let mut file = vec![0u8; sect_raw + idata.len()];
+        file[0] = b'M';
+        file[1] = b'Z';
+        file[0x3C..0x40].copy_from_slice(&0x80u32.to_le_bytes());
+
+        let pe = 0x80usize;
+        file[pe..pe + 4].copy_from_slice(b"PE\0\0");
+        file[pe + 4..pe + 6].copy_from_slice(&machine.to_le_bytes());
+        file[pe + 6..pe + 8].copy_from_slice(&1u16.to_le_bytes()); // NumberOfSections
+        file[pe + 20..pe + 22].copy_from_slice(&opt_size.to_le_bytes());
+
+        let opt = pe + 24;
+        file[opt..opt + 2].copy_from_slice(&opt_magic.to_le_bytes());
+        // DataDirectory[1] = Import (Export is [0] at +0/+4; Import follows at +8).
+        let dd_base = opt + if pe32 { 96 } else { 112 };
+        let n_dirs = dd_base - 4; // NumberOfRvaAndSizes sits just before the dirs
+        file[n_dirs..n_dirs + 4].copy_from_slice(&16u32.to_le_bytes());
+        file[dd_base + 8..dd_base + 12].copy_from_slice(&(sect_va as u32).to_le_bytes());
+        file[dd_base + 12..dd_base + 16].copy_from_slice(&(idata.len() as u32).to_le_bytes());
+
+        let sec = opt + opt_size as usize;
+        file[sec..sec + 8].copy_from_slice(b".idata\0\0");
+        file[sec + 8..sec + 12].copy_from_slice(&(idata.len() as u32).to_le_bytes()); // VirtualSize
+        file[sec + 12..sec + 16].copy_from_slice(&(sect_va as u32).to_le_bytes());
+        file[sec + 16..sec + 20].copy_from_slice(&(idata.len() as u32).to_le_bytes()); // SizeOfRawData
+        file[sec + 20..sec + 24].copy_from_slice(&(sect_raw as u32).to_le_bytes());
+
+        file[sect_raw..sect_raw + idata.len()].copy_from_slice(&idata);
+        fs::write(path, file).unwrap();
         path.to_path_buf()
     }
 
@@ -1347,6 +1639,7 @@ mod tests {
             classify_imports(&s(&["d3d10_1.dll", "d3d12.dll"])),
             Api::Dx12
         );
+        assert_eq!(classify_imports(&s(&["d3d9.dll"])), Api::Dx9);
         assert_eq!(classify_imports(&s(&["kernel32.dll"])), Api::Unknown);
     }
 
@@ -1436,6 +1729,22 @@ mod tests {
     }
 
     #[test]
+    fn resolve_target_launcher_file_prefers_shipping() {
+        // Ghostrunner-style: root launcher + Shipping under Game\Binaries\Win64.
+        let t = tempfile::tempdir().unwrap();
+        let d = t.path().join("Ghostrunner");
+        let bin = d.join("Ghostrunner").join("Binaries").join("Win64");
+        fs::create_dir_all(&bin).unwrap();
+        let launcher = make_pe(&d.join("Ghostrunner.exe"), PE_X64);
+        let shipping = make_pe(&bin.join("Ghostrunner-Win64-Shipping.exe"), PE_X64);
+        // Passing the launcher FILE must still resolve to Shipping.
+        let (exe, all) = resolve_target(&launcher).unwrap();
+        assert_eq!(exe, shipping);
+        assert!(all.contains(&shipping));
+        assert!(all.contains(&launcher));
+    }
+
+    #[test]
     fn find_game_exes_unreal_layout_prefers_shipping() {
         let t = tempfile::tempdir().unwrap();
         let d = t.path().join("SomeGame");
@@ -1486,28 +1795,63 @@ mod tests {
         assert_eq!(detect_api(&exe), Api::Unknown);
     }
 
-    /// A D3D9 game with dgVoodoo2 beside it is a D3D11 game at run time, and
-    /// that is the route the refusal text itself sends people to. Refusing it
-    /// anyway left Spore users stuck after doing exactly as told (#56).
+    /// Gothic 3: the exe has no Direct3D imports; Engine.dll does (d3d9.dll).
+    /// Sibling scan must surface Dx9; Install is allowed and will fetch dgVoodoo.
     #[test]
-    fn dgvoodoo_turns_a_d3d9_game_into_the_d3d11_path() {
-        std::env::set_var("DLSS5ONECLICK_SKIP_GPU_CHECK", "1");
+    fn detect_api_reads_dx9_from_sibling_engine_dll() {
         let t = tempfile::tempdir().unwrap();
         let d = t.path();
-        let exe =
-            testutil::make_pe_importing(&d.join("SporeApp.exe"), "d3d9.dll", &["Direct3DCreate9"]);
+        let exe = make_pe_with_imports(&d.join("Gothic3.exe"), PE_X86, &["engine.dll"]);
+        make_pe_with_imports(
+            &d.join("Engine.dll"),
+            PE_X86,
+            &["d3d9.dll", "d3dx9_40.dll", "kernel32.dll"],
+        );
+        assert_eq!(pe_imports(&exe), vec!["engine.dll".to_string()]);
+        assert!(pe_imports(&d.join("Engine.dll")).contains(&"d3d9.dll".to_string()));
         assert_eq!(detect_api(&exe), Api::Dx9);
+
+        std::env::set_var("DLSS5ONECLICK_SKIP_GPU_CHECK", "1");
         let st = inspect(&exe).unwrap();
         assert_eq!(st.api, Api::Dx9);
-        assert!(st.problems.iter().any(|p| p.contains("DirectX 9 game")));
+        assert!(st.needs_dgvoodoo(), "DX9 without dgVoodoo should need the install step");
+        assert!(
+            !st.problems.iter().any(|p| p.contains("DirectX 9")),
+            "DX9 without dgVoodoo must not hard-block Install: {:?}",
+            st.problems
+        );
 
-        // dgVoodoo2 in place: no refusal, and the D3D11 path from there on.
-        fs::write(d.join("dgVoodoo.conf"), b"[General]").unwrap();
-        fs::write(d.join("d3d9.dll"), b"MZ...dgVoodoo2 wrapper...").unwrap();
+        fs::write(d.join("dgVoodoo.conf"), b"[General]\nOutputAPI = bestavailable\n").unwrap();
         let st = inspect(&exe).unwrap();
-        assert_eq!(st.api, Api::Dx11);
-        assert!(!st.problems.iter().any(|p| p.contains("DirectX 9 game")));
-        assert!(!st.problems.iter().any(|p| p.contains("d3d9.dll proxy")));
+        assert_eq!(st.api, Api::Dx9);
+        assert!(!st.needs_dgvoodoo());
+        assert!(
+            !st.problems.iter().any(|p| p.contains("DirectX 9")),
+            "dgVoodoo present should stay clear: {:?}",
+            st.problems
+        );
+    }
+
+    /// Live check against a local Gothic 3 install when present.
+    #[test]
+    fn gothic3_live_detects_dx9_and_allows_install_without_dgvoodoo() {
+        let exe = std::path::Path::new(r"D:\Games\Gothic 3\Gothic3.exe");
+        if !exe.is_file() {
+            return;
+        }
+        std::env::set_var("DLSS5ONECLICK_SKIP_GPU_CHECK", "1");
+        assert_eq!(detect_api(exe), Api::Dx9, "Gothic3.exe must classify as DX9");
+        assert_eq!(detect_api(exe).label(), "DX9");
+        let st = inspect(exe).unwrap();
+        assert_eq!(st.api, Api::Dx9);
+        assert_eq!(st.bitness, 32);
+        let has_dg = is_dgvoodoo(exe.parent().unwrap());
+        assert_eq!(st.needs_dgvoodoo(), !has_dg);
+        assert!(
+            !st.problems.iter().any(|p| p.contains("DirectX 9")),
+            "Gothic 3 must not hard-block on missing dgVoodoo: {:?}",
+            st.problems
+        );
     }
 
     #[test]
@@ -1532,6 +1876,38 @@ mod tests {
         fs::remove_file(d.join("dgVoodoo.conf")).unwrap();
         fs::write(d.join("d3d9.dll"), b"MZ...dgVoodoo2 wrapper...").unwrap();
         assert!(is_dgvoodoo(d));
+    }
+
+    #[test]
+    fn dx9_needs_dgvoodoo_helper() {
+        assert_eq!(classify_imports(&["d3d9.dll".into()]), Api::Dx9);
+        let t = tempfile::tempdir().unwrap();
+        let d = t.path();
+        assert!(!is_dgvoodoo(d));
+        fs::write(d.join("dgVoodoo.conf"), b"[General]\nOutputAPI = bestavailable\n").unwrap();
+        assert!(is_dgvoodoo(d));
+    }
+
+    /// A renamed old ReShade (`d3d9.dll.off`) must not count as dgVoodoo.
+    #[test]
+    fn d3d9_off_is_not_dgvoodoo() {
+        let t = tempfile::tempdir().unwrap();
+        let d = t.path();
+        fs::write(d.join("d3d9.dll.off"), b"MZ old reshade").unwrap();
+        assert!(!is_dgvoodoo(d));
+    }
+
+    #[test]
+    fn dll_mentions_dgvoodoo_ascii_and_utf16() {
+        assert!(dll_mentions_dgvoodoo(b"MZ...dgVoodoo2 wrapper..."));
+        assert!(!dll_mentions_dgvoodoo(b"MZ some other wrapper"));
+        // Official 2.87.3 MS/x86/D3D9.dll embeds the name as UTF-16LE only.
+        let mut utf16 = b"MZ\0\0".to_vec();
+        for &c in b"dgVoodoo" {
+            utf16.push(c);
+            utf16.push(0);
+        }
+        assert!(dll_mentions_dgvoodoo(&utf16));
     }
 
     #[test]
@@ -1597,5 +1973,33 @@ mod tests {
         fs::write(sh.join(LUMENITE_KERNEL_FX), "technique Lumenite_Kernel {}").unwrap();
         fs::write(tx.join(LUMENITE_BLUENOISE), b"png").unwrap();
         assert!(inspect(&exe).unwrap().complete());
+    }
+
+    #[test]
+    fn unity_and_rt_likely_heuristics() {
+        let t = tempfile::tempdir().unwrap();
+        let d = t.path();
+        let exe = make_pe(&d.join("game.exe"), PE_X64);
+        assert!(!unity_likely(d));
+        assert!(!rt_likely(d));
+        fs::write(d.join("UnityPlayer.dll"), b"MZ").unwrap();
+        assert!(unity_likely(d));
+        fs::write(d.join("nvngx_dlssd.dll"), b"x").unwrap();
+        assert!(rt_likely(d));
+        let st = {
+            std::env::set_var("DLSS5ONECLICK_SKIP_GPU_CHECK", "1");
+            inspect(&exe).unwrap()
+        };
+        assert!(st.unity_likely);
+        assert!(st.rt_likely);
+    }
+
+    #[test]
+    fn unreal_likely_from_binaries_layout() {
+        let t = tempfile::tempdir().unwrap();
+        let win64 = t.path().join("MyGame").join("Binaries").join("Win64");
+        fs::create_dir_all(&win64).unwrap();
+        let exe = make_pe(&win64.join("MyGame-Win64-Shipping.exe"), PE_X64);
+        assert!(unreal_likely(&exe, &win64));
     }
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -2,12 +2,15 @@
 //! tiles, one Install button, progress, log.
 
 use crate::diagnose;
+use crate::feeder_cfg::{self, FeederKnobs};
 use crate::game::{self, GameStatus};
 use crate::installer::{self, Engine, StepState};
 use crate::library::{self, Game, Store};
 use crate::logo;
 use crate::net;
+use crate::quality_preset::QualityChoice;
 use crate::renodx;
+use crate::settings::Settings;
 use crate::text;
 use crate::theme::{self as t};
 use crate::update;
@@ -94,6 +97,16 @@ pub struct App {
     /// Official store marks (Simple Icons, CC0), white on transparent, tinted at paint time.
     store_icons: HashMap<Store, egui::TextureHandle>,
     kofi_icon: Option<egui::TextureHandle>,
+    /// Global defaults from settings.json.
+    settings: Settings,
+    /// Offline Feeder knobs for the selected game (None = not loaded / not installed).
+    knobs: Option<FeederKnobs>,
+    knobs_err: Option<String>,
+    knobs_dirty: bool,
+    /// Collapsed install log shows a one-line summary.
+    log_expanded: bool,
+    /// First-run tip dismissed (also persisted in eframe storage / settings).
+    tip_dismissed: bool,
 }
 
 pub const KOFI_URL: &str = "https://ko-fi.com/kindiboy";
@@ -104,6 +117,7 @@ const KOFI_RED: Color32 = Color32::from_rgb(0xff, 0x5e, 0x5b);
 enum Page {
     Games,
     Setup,
+    Settings,
     About,
 }
 
@@ -114,8 +128,7 @@ enum CardAction {
     None,
     /// Left click: open the game on the Setup page.
     Open,
-    /// Right click ▸ Update: install straight away, with the engine the game
-    /// already has, and show the Setup page so the progress is visible.
+    /// Install / Update / Re-install from the card (or context menu).
     Update,
     /// Right click ▸ Forget: drop a hand-added game from the list.
     Forget,
@@ -125,14 +138,57 @@ enum CardAction {
 #[derive(Debug, Clone)]
 struct GameMeta {
     api: &'static str,
+    /// Game ships its own DLSS (Mode::Native).
     has_dlss: bool,
+    /// Feeder / Native / Opti path label.
+    engine_path: &'static str,
     addon: bool,
     ready: bool,
-    /// This tool installed into that folder: the game is listed in its own
-    /// section at the top rather than under its store.
+    /// This tool installed into that folder.
     installed: bool,
     /// Components this tool placed that upstream has since moved past.
     stale: Vec<String>,
+    rt_likely: bool,
+    unreal_likely: bool,
+    unity_likely: bool,
+    re_engine: bool,
+    shaders_missing: bool,
+    wrong_folder: Option<String>,
+    /// Canonical Shipping (or best) exe.
+    exe: PathBuf,
+}
+
+fn meta_from_status(st: &GameStatus, latest: &installer::Latest) -> GameMeta {
+    let dir = st.game_dir();
+    GameMeta {
+        api: match st.api {
+            game::Api::Vulkan => "Vulkan",
+            game::Api::Dx9 => "DirectX 9",
+            game::Api::Dx10 => "DirectX 10",
+            game::Api::Dx11 => "DirectX 11",
+            game::Api::Dx12 => "DirectX 12",
+            game::Api::Unknown => "DirectX 12?",
+        },
+        has_dlss: st.mode == game::Mode::Native,
+        engine_path: if st.opti {
+            "Opti"
+        } else if st.mode == game::Mode::Native {
+            "Native"
+        } else {
+            "Feeder"
+        },
+        addon: st.dlss5_addon || st.opti,
+        ready: st.complete(),
+        installed: game::installed_by_tool(dir),
+        stale: installer::stale_components(dir, latest),
+        rt_likely: st.rt_likely,
+        unreal_likely: st.unreal_likely,
+        unity_likely: st.unity_likely,
+        re_engine: st.re_engine,
+        shaders_missing: game::shaders_missing(dir),
+        wrong_folder: game::install_folder_mismatch(&st.exe),
+        exe: st.exe.clone(),
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -192,6 +248,16 @@ impl App {
                 .storage
                 .and_then(|s| s.get_string("skip_version"))
                 .unwrap_or_default(),
+            settings: Settings::load(),
+            knobs: None,
+            knobs_err: None,
+            knobs_dirty: false,
+            log_expanded: true,
+            tip_dismissed: cc
+                .storage
+                .and_then(|s| s.get_string("tip_dismissed"))
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false),
         };
         app.refresh();
         if app.resolved_exe.is_some() {
@@ -245,7 +311,67 @@ impl App {
             self.renodx_on = false;
             self.start_renodx_lookup();
         }
+        self.reload_knobs_and_perf();
     }
+
+    fn reload_knobs_and_perf(&mut self) {
+        self.knobs = None;
+        self.knobs_err = None;
+        self.knobs_dirty = false;
+        let Some(exe) = self.resolved_exe.clone() else {
+            return;
+        };
+        let Some(dir) = exe.parent().map(|p| p.to_path_buf()) else {
+            return;
+        };
+        match feeder_cfg::load(&dir) {
+            Ok(k) => {
+                self.knobs = Some(k);
+            }
+            Err(e) => self.knobs_err = Some(format!("{e:#}")),
+        }
+    }
+
+
+    fn apply_settings_to_game(&mut self) {
+        let Some(exe) = self.exe() else { return };
+        let Some(dir) = exe.parent().map(|p| p.to_path_buf()) else {
+            return;
+        };
+        let s = &self.settings;
+        let mut k = self.knobs.clone().unwrap_or_default();
+        if let Some(v) = s.knobs.work_resolution {
+            k.work_resolution = v;
+        }
+        if let Some(v) = s.knobs.ofa_enabled {
+            k.ofa_enabled = v;
+        }
+        if let Some(v) = s.knobs.ofa_grid {
+            k.ofa_grid = v;
+        }
+        if let Some(v) = s.knobs.reset_mode {
+            k.reset_mode = v;
+        }
+        if let Some(v) = s.knobs.light_stab {
+            k.light_stab = v;
+        }
+        if let Some(v) = s.knobs.engine_velocity {
+            k.engine_velocity = v;
+        }
+        k.evaluate_stride = s.overlay.evaluate_stride;
+        k.log_detail = s.overlay.log_detail;
+        match feeder_cfg::save(&dir, &k) {
+            Ok(()) => {
+                self.knobs = Some(k);
+                self.knobs_err = None;
+                self.knobs_dirty = false;
+                self.log
+                    .push(LogLine::Ok("Applied Settings defaults to this game".into()));
+            }
+            Err(e) => self.knobs_err = Some(format!("{e:#}")),
+        }
+    }
+
 
     fn start_renodx_lookup(&mut self) {
         let Some(exe) = self.exe() else {
@@ -309,7 +435,7 @@ impl App {
             } else {
                 let p_tx = tx.clone();
                 let s_tx = tx.clone();
-                installer::run_all_with(
+                installer::run_all(
                     &exe,
                     engine,
                     with_renodx,
@@ -372,21 +498,7 @@ impl App {
                 let meta = game::resolve_target(&g.dir)
                     .and_then(|(exe, _)| game::inspect(&exe))
                     .ok()
-                    .map(|st| GameMeta {
-                        api: match st.api {
-                            game::Api::Vulkan => "Vulkan",
-                            game::Api::Dx10 => "DirectX 10",
-                            game::Api::Dx11 => "DirectX 11",
-                            game::Api::Dx12 => "DirectX 12",
-                            game::Api::Dx9 => "DirectX 9",
-                            game::Api::Unknown => "Unknown",
-                        },
-                        has_dlss: st.mode == game::Mode::Native,
-                        addon: st.dlss5_addon || st.opti,
-                        ready: st.complete(),
-                        installed: game::installed_by_tool(st.game_dir()),
-                        stale: installer::stale_components(st.game_dir(), &latest),
-                    });
+                    .map(|st| meta_from_status(&st, &latest));
                 if let Some(m) = meta {
                     let _ = mtx.send((i, m));
                 }
@@ -473,15 +585,19 @@ impl App {
         self.open_game(path);
     }
 
-    /// Right click ▸ Update: install with the engine the game already carries,
-    /// without leaving the Games page -- the card itself shows the progress.
+    /// Install / Update from a Games card: resolve Shipping exe, keep progress on the card.
     fn update_game(&mut self, path: PathBuf, index: usize) {
-        self.exe_text = path.to_string_lossy().into_owned();
+        // Prefer the canonical Shipping exe from meta when we already inspected it.
+        let target = self
+            .meta
+            .get(&index)
+            .map(|m| m.exe.clone())
+            .unwrap_or(path);
+        self.exe_text = target.to_string_lossy().into_owned();
         self.refresh();
         if let Some(Ok(st)) = &self.status {
-            // Whatever stops the Install button stops this too (anti-cheat, a
-            // foreign dxgi.dll): the Setup page is now open and says why.
             if !st.problems.is_empty() {
+                self.page = Page::Setup;
                 return;
             }
             self.engine = if st.opti {
@@ -489,14 +605,9 @@ impl App {
             } else {
                 Engine::ReShade
             };
-            // A RenoDX mod that is already installed stays installed: the
-            // step is only added when the lookup has found one, and Install
-            // refreshes what is there either way.
             self.updating = Some(index);
             self.start(None);
         } else {
-            // Could not even inspect it: the Setup page is the only place
-            // that can explain why.
             self.page = Page::Setup;
         }
     }
@@ -517,21 +628,7 @@ impl App {
             if let Some(m) = game::resolve_target(&g.dir)
                 .and_then(|(exe, _)| game::inspect(&exe))
                 .ok()
-                .map(|st| GameMeta {
-                    api: match st.api {
-                        game::Api::Vulkan => "Vulkan",
-                        game::Api::Dx10 => "DirectX 10",
-                        game::Api::Dx11 => "DirectX 11",
-                        game::Api::Dx12 => "DirectX 12",
-                        game::Api::Dx9 => "DirectX 9",
-                        game::Api::Unknown => "Unknown",
-                    },
-                    has_dlss: st.mode == game::Mode::Native,
-                    addon: st.dlss5_addon || st.opti,
-                    ready: st.complete(),
-                    installed: game::installed_by_tool(st.game_dir()),
-                    stale: installer::stale_components(st.game_dir(), &latest),
-                })
+                .map(|st| meta_from_status(&st, &latest))
             {
                 let _ = tx.send((index, m));
             }
@@ -714,6 +811,14 @@ const TILES_FEEDER: [Tile; 6] = [
     },
 ];
 
+/// Same Feeder row as above, but the in-game half is addon32 on 32-bit titles.
+const TILE_FEEDER32: Tile = Tile {
+    title: "DLSS5-Feeder",
+    detail: "dlss5-feed.addon32 · DLSS5_Feed.fx (detail residual + Optical Flow)",
+    ok: |s| s.feeder,
+    optional: false,
+};
+
 const TILE_OPTI: Tile = Tile {
     title: "OptiScaler + NR pass",
     detail: "Dagherbou fork as dxgi.dll · Insert opens its overlay",
@@ -815,7 +920,16 @@ fn base_tiles(st: Option<&GameStatus>, engine: Engine, upstream_on: bool) -> Vec
                 })
                 .collect()
         }
-        _ => TILES_FEEDER.iter().collect(),
+        _ => TILES_FEEDER
+            .iter()
+            .map(|t| {
+                if t.title == "DLSS5-Feeder" && st.is_some_and(|s| s.is32()) {
+                    &TILE_FEEDER32
+                } else {
+                    t
+                }
+            })
+            .collect(),
     }
 }
 
@@ -1361,9 +1475,20 @@ impl App {
             );
             p.rect_filled(band, CornerRadius::ZERO, Color32::from_black_alpha(170));
             let mut x = band.left() + 10.0;
+            let dlss_label = if m.has_dlss { "DLSS own" } else { "no DLSS" };
+            let ready_label = if !m.stale.is_empty() {
+                "stale"
+            } else if m.ready {
+                "ready"
+            } else if m.installed {
+                "partial"
+            } else {
+                "—"
+            };
             for (on, label) in [
-                (m.has_dlss, if m.has_dlss { "DLSS" } else { "no DLSS" }),
-                (m.addon, if m.addon { "add-on" } else { "no add-on" }),
+                (m.has_dlss, dlss_label),
+                (m.addon || m.installed, m.engine_path),
+                (m.ready && m.stale.is_empty(), ready_label),
             ] {
                 let cy = band.center().y;
                 p.circle_filled(
@@ -1371,13 +1496,24 @@ impl App {
                     3.0,
                     if on { t::ACCENT } else { t::TEXT_DIM },
                 );
-                let galley = p.layout_no_wrap(label.to_owned(), t::plex_medium(10.5), t::TEXT_SOFT);
+                let galley =
+                    p.layout_no_wrap(label.to_owned(), t::plex_medium(10.5), t::TEXT_SOFT);
                 p.galley(
                     egui::pos2(x + 11.0, cy - galley.size().y / 2.0),
                     galley.clone(),
                     t::TEXT_SOFT,
                 );
-                x += 11.0 + galley.size().x + 12.0;
+                x += 11.0 + galley.size().x + 10.0;
+            }
+            // Caps + warnings as tiny chips under the band (hover text carries detail).
+            if m.shaders_missing || m.wrong_folder.is_some() {
+                let warn = p.layout_no_wrap("!".to_owned(), t::plex_semibold(10.0), t::BG);
+                let badge = egui::Rect::from_min_size(
+                    egui::pos2(poster.right() - 22.0, poster.bottom() - 48.0),
+                    warn.size() + Vec2::new(10.0, 4.0),
+                );
+                p.rect_filled(badge, CornerRadius::same(6), t::WARN);
+                p.galley(badge.min + Vec2::new(5.0, 2.0), warn, t::BG);
             }
         }
         // Caption: store mark on the left, title beside it.
@@ -1407,14 +1543,38 @@ impl App {
             StrokeKind::Inside,
         );
         if hovered {
-            let stale = self
-                .meta
-                .get(&i)
+            let m = self.meta.get(&i);
+            let stale = m
                 .filter(|m| !m.stale.is_empty())
                 .map(|m| format!("\n\nOut of date:\n  {}", m.stale.join("\n  ")))
                 .unwrap_or_default();
+            let mut caps = String::new();
+            if let Some(m) = m {
+                let mut bits = Vec::new();
+                if m.rt_likely {
+                    bits.push("RT-likely");
+                }
+                if m.unreal_likely {
+                    bits.push("Unreal");
+                }
+                if m.unity_likely {
+                    bits.push("Unity");
+                }
+                if m.re_engine {
+                    bits.push("RE Engine");
+                }
+                if !bits.is_empty() {
+                    caps = format!("\nCaps: {}", bits.join(", "));
+                }
+                if m.shaders_missing {
+                    caps.push_str("\nWarning: shaders missing");
+                }
+                if let Some(w) = &m.wrong_folder {
+                    caps.push_str(&format!("\nWarning: {w}"));
+                }
+            }
             resp.clone()
-                .on_hover_text(format!("{}\n{}{stale}", g.title, g.dir.display()));
+                .on_hover_text(format!("{}{}\n{}{stale}{caps}", g.title, caps, g.dir.display()));
         }
         // Being installed right now: dim the poster, say so, and show how far
         // along it is, right where the user asked for it.
@@ -1471,6 +1631,56 @@ impl App {
         };
         let installed = self.meta.get(&i).is_some_and(|m| m.installed);
         let stale = self.meta.get(&i).is_some_and(|m| !m.stale.is_empty());
+        let meta_ready = self.meta.contains_key(&i);
+        // Primary Install / Update on the card (not only the context menu).
+        if meta_ready && self.updating != Some(i) && !self.running {
+            let label = if !installed {
+                "Install"
+            } else if stale {
+                "Update"
+            } else {
+                "Re-install"
+            };
+            let btn_h = 28.0;
+            let btn = egui::Rect::from_min_size(
+                egui::pos2(poster.left() + 10.0, poster.bottom() - btn_h - 30.0),
+                Vec2::new(poster.width() - 20.0, btn_h),
+            );
+            let btn_resp = ui.interact(
+                btn,
+                ui.id().with(("card_install", i)),
+                egui::Sense::click(),
+            );
+            let fill = if btn_resp.hovered() {
+                t::ACCENT
+            } else {
+                Color32::from_black_alpha(200)
+            };
+            ui.painter()
+                .rect_filled(btn, CornerRadius::same(7), fill);
+            ui.painter().rect_stroke(
+                btn,
+                CornerRadius::same(7),
+                Stroke::new(1.0, t::BORDER_STRONG),
+                StrokeKind::Inside,
+            );
+            let galley = ui.painter().layout_no_wrap(
+                label.to_owned(),
+                t::plex_semibold(12.0),
+                if btn_resp.hovered() { t::BG } else { t::TEXT },
+            );
+            ui.painter().galley(
+                egui::pos2(
+                    btn.center().x - galley.size().x / 2.0,
+                    btn.center().y - galley.size().y / 2.0,
+                ),
+                galley,
+                t::TEXT,
+            );
+            if btn_resp.clicked() {
+                action = CardAction::Update;
+            }
+        }
         if installed || g.store == Store::Manual {
             resp.context_menu(|ui| {
                 if installed {
@@ -1490,6 +1700,230 @@ impl App {
             });
         }
         action
+    }
+
+    fn settings_page(&mut self, ui: &mut egui::Ui) {
+        ui.label(
+            RichText::new("Settings")
+                .font(t::sora(16.0))
+                .color(t::TEXT),
+        );
+        ui.label(
+            RichText::new(
+                "Defaults applied on new Install. Optional: apply to the game open on Setup.",
+            )
+            .font(t::plex(12.0))
+            .color(t::TEXT_MUTED),
+        );
+        ui.add_space(10.0);
+
+        ui.label(
+            RichText::new("Quality seed")
+                .font(t::plex_semibold(13.0))
+                .color(t::TEXT),
+        );
+        ui.horizontal(|ui| {
+            for c in [
+                QualityChoice::Auto,
+                QualityChoice::Low,
+                QualityChoice::Medium,
+                QualityChoice::High,
+            ] {
+                let on = self.settings.quality_choice() == c;
+                if ui.selectable_label(on, c.label()).clicked() {
+                    self.settings.set_quality_choice(c);
+                }
+            }
+        });
+
+        ui.add_space(8.0);
+        ui.label(
+            RichText::new("Feeder knobs defaults")
+                .font(t::plex_semibold(13.0))
+                .color(t::TEXT),
+        );
+        {
+            let k = &mut self.settings.knobs;
+            let mut work = k.work_resolution.unwrap_or(100);
+            if ui
+                .add(egui::Slider::new(&mut work, 50..=100).text("work_resolution %"))
+                .changed()
+            {
+                k.work_resolution = Some(work);
+            }
+            let mut ofa = k.ofa_enabled.unwrap_or(false);
+            if ui.checkbox(&mut ofa, "ofa_enabled").changed() {
+                k.ofa_enabled = Some(ofa);
+            }
+            let mut reset = k.reset_mode.unwrap_or(2);
+            if ui
+                .add(
+                    egui::Slider::new(&mut reset, 0..=2)
+                        .text("reset_mode (0 off / 1 every / 2 adaptive)"),
+                )
+                .changed()
+            {
+                k.reset_mode = Some(reset);
+            }
+            let mut ls = k.light_stab.unwrap_or(false);
+            if ui.checkbox(&mut ls, "light_stab").changed() {
+                k.light_stab = Some(ls);
+            }
+            let mut ev = k.engine_velocity.unwrap_or(true);
+            if ui.checkbox(&mut ev, "engine_velocity").changed() {
+                k.engine_velocity = Some(ev);
+            }
+        }
+
+        ui.add_space(8.0);
+        ui.label(
+            RichText::new("Overlay UX defaults")
+                .font(t::plex_semibold(13.0))
+                .color(t::TEXT),
+        );
+        ui.add(
+            egui::Slider::new(&mut self.settings.overlay.log_detail, 0..=2).text("log_detail"),
+        );
+        ui.add(
+            egui::Slider::new(&mut self.settings.overlay.evaluate_stride, 1..=4)
+                .text("evaluate_stride"),
+        );
+        ui.add(
+            egui::Slider::new(&mut self.settings.overlay.log_frames, 0..=20).text("log_frames"),
+        );
+
+        ui.add_space(12.0);
+        ui.horizontal(|ui| {
+            if ui.button("Save settings.json").clicked() {
+                if let Err(e) = self.settings.save() {
+                    self.last_error = Some(format!("{e:#}"));
+                }
+            }
+            if ui
+                .add_enabled(
+                    self.resolved_exe.is_some(),
+                    egui::Button::new("Apply defaults to this game"),
+                )
+                .clicked()
+            {
+                let _ = self.settings.save();
+                self.apply_settings_to_game();
+            }
+        });
+        ui.label(
+            RichText::new(format!("File: {}", Settings::path().display()))
+                .font(t::mono(11.0))
+                .color(t::TEXT_DIM),
+        );
+    }
+
+    fn knobs_panel(&mut self, ui: &mut egui::Ui) {
+        ui.add_space(6.0);
+        ui.separator();
+        ui.label(
+            RichText::new("Feeder knobs (offline)")
+                .font(t::plex_semibold(13.0))
+                .color(t::TEXT),
+        );
+        if self.knobs.is_none() {
+            if let Some(err) = &self.knobs_err {
+                ui.label(
+                    RichText::new(err.clone())
+                        .font(t::plex(12.0))
+                        .color(t::TEXT_MUTED),
+                );
+                if ui.button("Install DLSS 5").clicked() {
+                    self.start(None);
+                }
+            } else {
+                ui.label(
+                    RichText::new("Select a game first.")
+                        .font(t::plex(12.0))
+                        .color(t::TEXT_DIM),
+                );
+            }
+            return;
+        }
+
+        let mut changed = false;
+        {
+            let k = self.knobs.as_mut().unwrap();
+            let wr = ui
+                .add(egui::Slider::new(&mut k.work_resolution, 50..=100).text("work_resolution %"))
+                .changed();
+            changed |= wr;
+            let sharp = ui
+                .add(
+                    egui::Slider::new(&mut k.work_sharpness, 0.0..=1.0)
+                        .text("work_sharpness"),
+                )
+                .changed();
+            changed |= sharp;
+            changed |= ui.checkbox(&mut k.ofa_enabled, "Optical Flow (ofa)").changed();
+            if k.ofa_enabled {
+                changed |= ui
+                    .add(egui::Slider::new(&mut k.ofa_grid, 0..=4).text("ofa_grid"))
+                    .changed();
+            }
+            let reset = ui
+                .add(egui::Slider::new(&mut k.reset_mode, 0..=2).text("reset_mode"))
+                .changed();
+            changed |= reset;
+            changed |= ui.checkbox(&mut k.light_stab, "light_stab").changed();
+            changed |= ui
+                .checkbox(&mut k.engine_velocity, "engine_velocity")
+                .changed();
+            changed |= ui
+                .add(egui::Slider::new(&mut k.evaluate_stride, 1..=4).text("evaluate_stride"))
+                .changed();
+            changed |= ui
+                .add(
+                    egui::Slider::new(&mut k.appearance_threshold, 0.01..=0.12)
+                        .text("appearance_threshold"),
+                )
+                .changed();
+            changed |= ui
+                .add(
+                    egui::Slider::new(&mut k.lighting_threshold, 0.01..=0.12)
+                        .text("lighting_threshold"),
+                )
+                .changed();
+            changed |= ui
+                .add(
+                    egui::Slider::new(&mut k.detail_threshold, 0.005..=0.08)
+                        .text("detail_threshold"),
+                )
+                .changed();
+        }
+        if changed {
+            self.knobs_dirty = true;
+        }
+        ui.horizontal(|ui| {
+            let write = egui::Button::new(if self.knobs_dirty {
+                "Write cfg *"
+            } else {
+                "Write cfg"
+            });
+            if ui.add_enabled(self.knobs.is_some(), write).clicked() {
+                if let (Some(exe), Some(k)) = (self.exe(), self.knobs.clone()) {
+                    if let Some(dir) = exe.parent() {
+                        match feeder_cfg::save(dir, &k) {
+                            Ok(()) => {
+                                self.knobs_dirty = false;
+                                self.log.push(LogLine::Ok(
+                                    "Wrote dlss5-feed.cfg + FX uniforms (Feeder reloads ~60 frames / next launch)"
+                                        .into(),
+                                ));
+                            }
+                            Err(e) => self.log.push(LogLine::Fail(format!("{e:#}"))),
+                        }
+                    }
+                }
+            }
+            if ui.button("Reload from disk").clicked() {
+                self.reload_knobs_and_perf();
+            }
+        });
     }
 }
 
@@ -1595,6 +2029,10 @@ impl eframe::App for App {
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
         storage.set_string("exe", self.exe_text.clone());
         storage.set_string("skip_version", self.skipped_version.clone());
+        storage.set_string(
+            "tip_dismissed",
+            if self.tip_dismissed { "1" } else { "0" }.into(),
+        );
     }
 
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
@@ -1668,6 +2106,7 @@ impl eframe::App for App {
                     for (page, label, enabled) in [
                         (Page::Games, "Games", true),
                         (Page::Setup, "Setup", setup_enabled),
+                        (Page::Settings, "Settings", true),
                         (Page::About, "About", true),
                     ] {
                         let active = self.page == page;
@@ -1921,6 +2360,46 @@ impl eframe::App for App {
             }
         }
 
+        if !self.tip_dismissed {
+            egui::Panel::top("first_run_tip")
+                .frame(
+                    Frame::new()
+                        .fill(t::TILE)
+                        .inner_margin(Margin {
+                            left: 18,
+                            right: 18,
+                            top: 10,
+                            bottom: 10,
+                        })
+                        .stroke(Stroke::new(1.0, t::BORDER)),
+                )
+                .show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.vertical(|ui| {
+                            ui.label(
+                                RichText::new("Quick tip")
+                                    .font(t::plex_semibold(13.0))
+                                    .color(t::TEXT),
+                            );
+                            ui.label(
+                                RichText::new(
+                                    "This tool installs ReShade + DLSS5-Feeder + neural DLSS for games that ship without DLSS. \
+                                     After Install: in-game press Home → Add-ons tab → enable DLSS 5 Neural Rendering. \
+                                     Use Settings to seed Feeder defaults on the next Install.",
+                                )
+                                .font(t::plex(12.0))
+                                .color(t::TEXT_SOFT),
+                            );
+                        });
+                        ui.with_layout(Layout::right_to_left(Align::TOP), |ui| {
+                            if ui.button("Got it").clicked() {
+                                self.tip_dismissed = true;
+                            }
+                        });
+                    });
+                });
+        }
+
         egui::CentralPanel::default()
             .frame(Frame::new().fill(t::PANEL).inner_margin(Margin {
                 left: 24,
@@ -1933,6 +2412,10 @@ impl eframe::App for App {
                 match self.page {
                     Page::Games => {
                         self.games_page(ui);
+                        return;
+                    }
+                    Page::Settings => {
+                        self.settings_page(ui);
                         return;
                     }
                     Page::About => {
@@ -2066,11 +2549,15 @@ impl eframe::App for App {
                             let mut choice = game::mode_override();
                             let name = |m: Option<game::Mode>| match m {
                                 None => match s.mode_detected {
-                                    game::Mode::Native => "Auto: native DLSS · add-on hooks the game",
-                                    game::Mode::Feeder => "Auto: no DLSS · Feeder path",
+                                    game::Mode::Native => {
+                                        "Auto: native DLSS · renodx hooks game (Feeder Optimize N/A)"
+                                    }
+                                    game::Mode::Feeder => "Auto: no DLSS · Feeder path + Optimize",
                                 },
-                                Some(game::Mode::Native) => "Force native DLSS",
-                                Some(game::Mode::Feeder) => "Force no-DLSS (Feeder)",
+                                Some(game::Mode::Native) => {
+                                    "Force native DLSS (Feeder Optimize N/A)"
+                                }
+                                Some(game::Mode::Feeder) => "Force no-DLSS (Feeder + Optimize)",
                             };
                             let before = choice;
                             egui::ComboBox::from_id_salt("mode_pick")
@@ -2093,6 +2580,49 @@ impl eframe::App for App {
                             .font(t::plex(12.0))
                             .color(t::DANGER),
                     );
+                }
+                if ok_status
+                    .as_ref()
+                    .is_some_and(|s| s.needs_dgvoodoo() && problems.is_empty())
+                {
+                    ui.label(
+                        RichText::new(
+                            "DirectX 9: Install will download dgVoodoo 2.87.3 into the game folder \
+                             first (official GitHub release → d3d9.dll + dgVoodoo.conf), then continue \
+                             with ReShade / Feeder. / DirectX 9: Install сначала скачает dgVoodoo 2.87.3 \
+                             в папку игры, затем продолжит установку.",
+                        )
+                        .font(t::plex(12.0))
+                        .color(t::TEXT_SOFT),
+                    );
+                }
+                if let Some(s) = &ok_status {
+                    let mut caps: Vec<&str> = Vec::new();
+                    if s.mode == game::Mode::Native {
+                        caps.push("Native DLSS (Feeder Optimize N/A)");
+                    }
+                    if s.rt_likely {
+                        caps.push("RT-likely");
+                    }
+                    if s.re_engine {
+                        caps.push("RE Engine");
+                    }
+                    if s.unreal_likely {
+                        caps.push("Unreal-likely");
+                    }
+                    if s.unity_likely {
+                        caps.push("Unity-likely");
+                    }
+                    if s.api == game::Api::Dx12 && s.mode == game::Mode::Feeder {
+                        caps.push("DX12 Feeder (Optimize, no OFA)");
+                    }
+                    if !caps.is_empty() {
+                        ui.label(
+                            RichText::new(format!("Caps: {}", caps.join(" · ")))
+                                .font(t::plex(11.5))
+                                .color(t::TEXT_MUTED),
+                        );
+                    }
                 }
                 if let Some(ac) = ok_status.as_ref().and_then(|s| s.anticheat) {
                     let mut on = game::ignore_anticheat();
@@ -2364,18 +2894,85 @@ impl eframe::App for App {
                     {
                         self.run_diagnose();
                     }
+                    let vulkan = ok_status
+                        .as_ref()
+                        .is_some_and(|s| s.api == game::Api::Vulkan);
+                    if vulkan {
+                        let vk_btn = egui::Button::new(
+                            RichText::new("Copy Vulkan Feeder kit")
+                                .font(t::plex_medium(13.0))
+                                .color(t::TEXT_OFF),
+                        )
+                        .fill(Color32::TRANSPARENT)
+                        .stroke(Stroke::new(1.0, t::BORDER_STRONG))
+                        .corner_radius(CornerRadius::same(8))
+                        .min_size(Vec2::new(170.0, 42.0));
+                        if ui
+                            .add_enabled(!self.running, vk_btn)
+                            .on_hover_text(
+                                "Copies dlss5-feed.addon64 + DLSS5_Feed.fx + VULKAN-SETUP.txt. \
+                                 Does not register a Vulkan layer — finish with ReShade Setup.",
+                            )
+                            .clicked()
+                        {
+                            if let Some(exe) = self.exe() {
+                                let dir = exe.parent().unwrap().to_path_buf();
+                                match installer::copy_vulkan_feeder_kit(&dir) {
+                                    Ok(files) => {
+                                        self.log.push(LogLine::Ok(format!(
+                                            "Vulkan kit: {}",
+                                            files.join(", ")
+                                        )));
+                                        self.inspect_resolved();
+                                    }
+                                    Err(e) => {
+                                        self.log.push(LogLine::Fail(format!("{e:#}")));
+                                        self.last_error = Some(format!("{e:#}"));
+                                    }
+                                }
+                            }
+                        }
+                    }
                     ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                        let missing = ok_status
+                            .as_ref()
+                            .map(installer::missing_install_files)
+                            .unwrap_or_default();
+                        let stale = self
+                            .exe()
+                            .and_then(|e| {
+                                self.meta
+                                    .values()
+                                    .find(|m| m.exe == e)
+                                    .map(|m| m.stale.clone())
+                            })
+                            .unwrap_or_default();
                         let msg = if self.running || !self.progress_msg.is_empty() {
                             self.progress_msg.clone()
+                        } else if !missing.is_empty() {
+                            format!("Incomplete: missing {}", missing.join(", "))
+                        } else if !stale.is_empty() {
+                            format!("Update available: {}", stale.join("; "))
                         } else if complete {
                             "Everything is in place.".to_owned()
                         } else {
                             String::new()
                         };
-                        let color = if msg.starts_with("Failed") { t::DANGER } else { t::ACCENT };
+                        let color = if msg.starts_with("Failed")
+                            || msg.starts_with("Incomplete")
+                        {
+                            t::DANGER
+                        } else if msg.starts_with("Update available") {
+                            t::WARN
+                        } else {
+                            t::ACCENT
+                        };
                         ui.label(RichText::new(msg).font(t::plex_medium(12.0)).color(color));
                     });
                 });
+
+                // Offline knobs / expected FPS from Feeder perf log.
+                self.knobs_panel(ui);
 
                 // ── progress ──────────────────────────────────────
                 let (bar, _) = ui.allocate_exact_size(Vec2::new(ui.available_width(), 4.0), egui::Sense::hover());
@@ -2389,39 +2986,98 @@ impl eframe::App for App {
 
                 // ── log ───────────────────────────────────────────
                 let hint_h = 34.0;
-                let log_h = (ui.available_height() - hint_h - 12.0).max(80.0);
-                Frame::new()
-                    .fill(t::BG)
-                    .stroke(Stroke::new(1.0, t::BORDER))
-                    .corner_radius(CornerRadius::same(8))
-                    .inner_margin(Margin::symmetric(12, 10))
-                    .show(ui, |ui| {
-                        ui.set_width(ui.available_width());
-                        ui.set_height(log_h - 20.0);
-                        egui::ScrollArea::vertical().stick_to_bottom(true).show(ui, |ui| {
-                            ui.spacing_mut().item_spacing.y = 2.0;
+                let fails: Vec<&LogLine> = self
+                    .log
+                    .iter()
+                    .filter(|l| matches!(l, LogLine::Fail(_)))
+                    .collect();
+                let oks = self
+                    .log
+                    .iter()
+                    .filter(|l| matches!(l, LogLine::Ok(_) | LogLine::Step(_)))
+                    .count();
+                let summary = if self.log.is_empty() {
+                    "Install log — empty".to_owned()
+                } else if !fails.is_empty() {
+                    format!(
+                        "Install log — {} error(s), {} step(s)",
+                        fails.len(),
+                        oks
+                    )
+                } else {
+                    format!("Install log — {} line(s)", self.log.len())
+                };
+                ui.horizontal(|ui| {
+                    let arrow = if self.log_expanded { "▾" } else { "▸" };
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                RichText::new(format!("{arrow} {summary}"))
+                                    .font(t::plex_medium(12.0))
+                                    .color(if fails.is_empty() {
+                                        t::TEXT_MUTED
+                                    } else {
+                                        t::DANGER
+                                    }),
+                            )
+                            .fill(Color32::TRANSPARENT)
+                            .stroke(Stroke::NONE),
+                        )
+                        .clicked()
+                    {
+                        self.log_expanded = !self.log_expanded;
+                    }
+                });
+                if self.log_expanded {
+                    let log_h = (ui.available_height() - hint_h - 12.0).max(80.0);
+                    Frame::new()
+                        .fill(t::BG)
+                        .stroke(Stroke::new(1.0, t::BORDER))
+                        .corner_radius(CornerRadius::same(8))
+                        .inner_margin(Margin::symmetric(12, 10))
+                        .show(ui, |ui| {
                             ui.set_width(ui.available_width());
-                            for l in &self.log {
-                                match l {
-                                    LogLine::Step(s) => {
-                                        let (idx, rest) = s.split_once(' ').unwrap_or(("", s));
-                                        ui.horizontal(|ui| {
-                                            ui.spacing_mut().item_spacing.x = 6.0;
-                                            ui.label(RichText::new(idx).font(t::mono(11.5)).color(t::TEXT_DIM));
-                                            ui.label(RichText::new(rest).font(t::mono(11.5)).color(t::TEXT_MUTED));
-                                        });
+                            ui.set_height(log_h - 20.0);
+                            egui::ScrollArea::vertical().stick_to_bottom(fails.is_empty()).show(ui, |ui| {
+                                ui.spacing_mut().item_spacing.y = 2.0;
+                                ui.set_width(ui.available_width());
+                                // Failures first so they are not buried under ok lines.
+                                let mut ordered: Vec<&LogLine> = Vec::with_capacity(self.log.len());
+                                ordered.extend(self.log.iter().filter(|l| matches!(l, LogLine::Fail(_))));
+                                ordered.extend(self.log.iter().filter(|l| !matches!(l, LogLine::Fail(_))));
+                                for l in ordered {
+                                    match l {
+                                        LogLine::Step(s) => {
+                                            let (idx, rest) = s.split_once(' ').unwrap_or(("", s));
+                                            ui.horizontal(|ui| {
+                                                ui.spacing_mut().item_spacing.x = 6.0;
+                                                ui.label(RichText::new(idx).font(t::mono(11.5)).color(t::TEXT_DIM));
+                                                ui.label(RichText::new(rest).font(t::mono(11.5)).color(t::TEXT_MUTED));
+                                            });
+                                        }
+                                        LogLine::Ok(s) => { ui.label(RichText::new(format!("      {s}")).font(t::mono(11.5)).color(t::ACCENT)); }
+                                        LogLine::Fail(s) => { ui.label(RichText::new(format!("      {s}")).font(t::mono(11.5)).color(t::DANGER)); }
+                                        LogLine::Plain(s) => { ui.label(RichText::new(s).font(t::mono(11.5)).color(t::TEXT)); }
                                     }
-                                    LogLine::Ok(s) => { ui.label(RichText::new(format!("      {s}")).font(t::mono(11.5)).color(t::ACCENT)); }
-                                    LogLine::Fail(s) => { ui.label(RichText::new(format!("      {s}")).font(t::mono(11.5)).color(t::DANGER)); }
-                                    LogLine::Plain(s) => { ui.label(RichText::new(s).font(t::mono(11.5)).color(t::TEXT)); }
                                 }
-                            }
+                            });
                         });
-                    });
+                } else if !fails.is_empty() {
+                    ui.label(
+                        RichText::new(fails.iter().filter_map(|l| match l {
+                            LogLine::Fail(s) => Some(s.as_str()),
+                            _ => None,
+                        }).take(2).collect::<Vec<_>>().join(" · "))
+                        .font(t::mono(11.0))
+                        .color(t::DANGER),
+                    );
+                }
 
                 ui.label(RichText::new(
                     "After install, in game: press Home for the ReShade overlay, open the DLSS 5 Neural Rendering panel and enable it. \
-                     Keep MSAA/SSAA off. Check dlss5-feed.log next to the exe for 'feature ready'.")
+                     Keep MSAA/SSAA off. Check dlss5-feed.log next to the exe for 'feature ready'. \
+                     Optional TRAA (LUMENITE: TRAA): keep it BELOW DLSS 5 Feed; Edge Detection=Geometric + Protect UI/text on — \
+                     re-run install to patch TRAA if UI still smears.")
                     .font(t::plex(11.0)).color(t::TEXT_DIM));
             });
 
@@ -2434,7 +3090,7 @@ impl eframe::App for App {
                     ui.label("Remove the DLSS 5 files from this game?
 
 Remove takes out what this tool added; ReShade stays.
-Remove incl. ReShade also deletes ReShade (dxgi.dll, ini files, reshade-shaders) - refused if any add-on or shader this tool did not install is still there.");
+Remove incl. ReShade also deletes ReShade (dxgi.dll, ini/logs). Leftover shaders in reshade-shaders are kept; refused only if a foreign .addon64/.addon32 is still there. Never touches dgVoodoo d3d9.dll.");
                     ui.horizontal(|ui| {
                         if ui.button("Remove").clicked() { self.confirm_remove = false; self.start(Some(false)); }
                         if ui.button("Remove incl. ReShade").clicked() { self.confirm_remove = false; self.start(Some(true)); }
@@ -2462,7 +3118,10 @@ pub fn run() -> eframe::Result {
     let mut viewport = egui::ViewportBuilder::default()
         .with_inner_size([1100.0, 780.0])
         .with_min_inner_size([880.0, 620.0])
-        .with_title(concat!("DLSS5oneclick ", env!("CARGO_PKG_VERSION")));
+        .with_title(concat!(
+            "DLSS5oneclick ",
+            env!("CARGO_PKG_VERSION"),
+        ));
     if let Some(icon) = logo::icon_data() {
         viewport = viewport.with_icon(icon);
     }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -332,7 +332,6 @@ impl App {
         }
     }
 
-
     fn apply_settings_to_game(&mut self) {
         let Some(exe) = self.exe() else { return };
         let Some(dir) = exe.parent().map(|p| p.to_path_buf()) else {
@@ -371,7 +370,6 @@ impl App {
             Err(e) => self.knobs_err = Some(format!("{e:#}")),
         }
     }
-
 
     fn start_renodx_lookup(&mut self) {
         let Some(exe) = self.exe() else {
@@ -588,11 +586,7 @@ impl App {
     /// Install / Update from a Games card: resolve Shipping exe, keep progress on the card.
     fn update_game(&mut self, path: PathBuf, index: usize) {
         // Prefer the canonical Shipping exe from meta when we already inspected it.
-        let target = self
-            .meta
-            .get(&index)
-            .map(|m| m.exe.clone())
-            .unwrap_or(path);
+        let target = self.meta.get(&index).map(|m| m.exe.clone()).unwrap_or(path);
         self.exe_text = target.to_string_lossy().into_owned();
         self.refresh();
         if let Some(Ok(st)) = &self.status {
@@ -1496,8 +1490,7 @@ impl App {
                     3.0,
                     if on { t::ACCENT } else { t::TEXT_DIM },
                 );
-                let galley =
-                    p.layout_no_wrap(label.to_owned(), t::plex_medium(10.5), t::TEXT_SOFT);
+                let galley = p.layout_no_wrap(label.to_owned(), t::plex_medium(10.5), t::TEXT_SOFT);
                 p.galley(
                     egui::pos2(x + 11.0, cy - galley.size().y / 2.0),
                     galley.clone(),
@@ -1573,8 +1566,12 @@ impl App {
                     caps.push_str(&format!("\nWarning: {w}"));
                 }
             }
-            resp.clone()
-                .on_hover_text(format!("{}{}\n{}{stale}{caps}", g.title, caps, g.dir.display()));
+            resp.clone().on_hover_text(format!(
+                "{}{}\n{}{stale}{caps}",
+                g.title,
+                caps,
+                g.dir.display()
+            ));
         }
         // Being installed right now: dim the poster, say so, and show how far
         // along it is, right where the user asked for it.
@@ -1646,18 +1643,14 @@ impl App {
                 egui::pos2(poster.left() + 10.0, poster.bottom() - btn_h - 30.0),
                 Vec2::new(poster.width() - 20.0, btn_h),
             );
-            let btn_resp = ui.interact(
-                btn,
-                ui.id().with(("card_install", i)),
-                egui::Sense::click(),
-            );
+            let btn_resp =
+                ui.interact(btn, ui.id().with(("card_install", i)), egui::Sense::click());
             let fill = if btn_resp.hovered() {
                 t::ACCENT
             } else {
                 Color32::from_black_alpha(200)
             };
-            ui.painter()
-                .rect_filled(btn, CornerRadius::same(7), fill);
+            ui.painter().rect_filled(btn, CornerRadius::same(7), fill);
             ui.painter().rect_stroke(
                 btn,
                 CornerRadius::same(7),
@@ -1703,14 +1696,12 @@ impl App {
     }
 
     fn settings_page(&mut self, ui: &mut egui::Ui) {
-        ui.label(
-            RichText::new("Settings")
-                .font(t::sora(16.0))
-                .color(t::TEXT),
-        );
+        ui.label(RichText::new("Settings").font(t::sora(16.0)).color(t::TEXT));
         ui.label(
             RichText::new(
-                "Defaults applied on new Install. Optional: apply to the game open on Setup.",
+                "User install defaults — saved to settings.json and applied on new Install \
+                 (optional: Apply to the game open on Setup). Separate from Feeder built-in \
+                 defaults (what the add-on writes when no dlss5-feed.cfg exists).",
             )
             .font(t::plex(12.0))
             .color(t::TEXT_MUTED),
@@ -1718,7 +1709,7 @@ impl App {
         ui.add_space(10.0);
 
         ui.label(
-            RichText::new("Quality seed")
+            RichText::new("Quality seed (user install)")
                 .font(t::plex_semibold(13.0))
                 .color(t::TEXT),
         );
@@ -1738,9 +1729,16 @@ impl App {
 
         ui.add_space(8.0);
         ui.label(
-            RichText::new("Feeder knobs defaults")
+            RichText::new("Feeder knobs (user install overrides)")
                 .font(t::plex_semibold(13.0))
                 .color(t::TEXT),
+        );
+        ui.label(
+            RichText::new(
+                "Unset sliders follow the quality seed. Explicit values override on Install.",
+            )
+            .font(t::plex(11.0))
+            .color(t::TEXT_DIM),
         );
         {
             let k = &mut self.settings.knobs;
@@ -1777,20 +1775,16 @@ impl App {
 
         ui.add_space(8.0);
         ui.label(
-            RichText::new("Overlay UX defaults")
+            RichText::new("Overlay UX (user install)")
                 .font(t::plex_semibold(13.0))
                 .color(t::TEXT),
         );
-        ui.add(
-            egui::Slider::new(&mut self.settings.overlay.log_detail, 0..=2).text("log_detail"),
-        );
+        ui.add(egui::Slider::new(&mut self.settings.overlay.log_detail, 0..=2).text("log_detail"));
         ui.add(
             egui::Slider::new(&mut self.settings.overlay.evaluate_stride, 1..=4)
                 .text("evaluate_stride"),
         );
-        ui.add(
-            egui::Slider::new(&mut self.settings.overlay.log_frames, 0..=20).text("log_frames"),
-        );
+        ui.add(egui::Slider::new(&mut self.settings.overlay.log_frames, 0..=20).text("log_frames"));
 
         ui.add_space(12.0);
         ui.horizontal(|ui| {
@@ -1809,7 +1803,26 @@ impl App {
                 let _ = self.settings.save();
                 self.apply_settings_to_game();
             }
+            if ui
+                .button("Reset to Feeder defaults")
+                .on_hover_text(
+                    "Restore form to Feeder stock: work_resolution=100, ofa off (grid 2 / perf 10), \
+                     reset_mode=2 adaptive, light_stab off, engine_velocity on, overlay log_detail=1 / \
+                     evaluate_stride=1 / log_frames=3, quality Auto.",
+                )
+                .clicked()
+            {
+                self.settings.reset_to_feeder_defaults();
+            }
         });
+        ui.label(
+            RichText::new(
+                "Feeder built-in defaults = stock add-on cfg (not your settings.json). \
+                 Reset above copies those into this form; Save to persist.",
+            )
+            .font(t::plex(11.0))
+            .color(t::TEXT_DIM),
+        );
         ui.label(
             RichText::new(format!("File: {}", Settings::path().display()))
                 .font(t::mono(11.0))
@@ -1853,13 +1866,12 @@ impl App {
                 .changed();
             changed |= wr;
             let sharp = ui
-                .add(
-                    egui::Slider::new(&mut k.work_sharpness, 0.0..=1.0)
-                        .text("work_sharpness"),
-                )
+                .add(egui::Slider::new(&mut k.work_sharpness, 0.0..=1.0).text("work_sharpness"))
                 .changed();
             changed |= sharp;
-            changed |= ui.checkbox(&mut k.ofa_enabled, "Optical Flow (ofa)").changed();
+            changed |= ui
+                .checkbox(&mut k.ofa_enabled, "Optical Flow (ofa)")
+                .changed();
             if k.ofa_enabled {
                 changed |= ui
                     .add(egui::Slider::new(&mut k.ofa_grid, 0..=4).text("ofa_grid"))
@@ -3118,10 +3130,7 @@ pub fn run() -> eframe::Result {
     let mut viewport = egui::ViewportBuilder::default()
         .with_inner_size([1100.0, 780.0])
         .with_min_inner_size([880.0, 620.0])
-        .with_title(concat!(
-            "DLSS5oneclick ",
-            env!("CARGO_PKG_VERSION"),
-        ));
+        .with_title(concat!("DLSS5oneclick ", env!("CARGO_PKG_VERSION"),));
     if let Some(icon) = logo::icon_data() {
         viewport = viewport.with_icon(icon);
     }

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1,21 +1,28 @@
-//! The six install steps, in the order the DLSS5-Feeder README lists them.
+//! The install steps, in the order the DLSS5-Feeder README lists them.
 //!
 //! Sources (verified 2026-08-31):
+//! 0. dgVoodoo 2.87.3 — only when the game is Direct3D 9 and dgVoodoo is not
+//!    already in the game folder. Downloaded from the official GitHub release
+//!    (not bundled); extracts `MS/{x86|x64}/D3D9.dll` by exe bitness → `d3d9.dll`
+//!    + smart-merged conf (force OutputAPI, floor VRAM, preserve the rest).
 //! 1. ReShade add-on build — https://reshade.me links `/downloads/ReShade_Setup_<ver>_Addon.exe`;
 //!    that exe has an appended ZIP with ReShade64.dll / ReShade32.dll. Dropped as dxgi.dll.
 //! 2. ReShade shader headers — raw.githubusercontent.com/crosire/reshade-shaders/slim/Shaders/
 //!    {ReShade.fxh, ReShadeUI.fxh, DrawText.fxh}; the setup exe only carries the DLLs.
-//! 3. DLSS5-Feeder — jlrouzies-fr/DLSS5-Feeder latest release, loose assets
-//!    `dlss5-feed.addon64` + `DLSS5_Feed.fx` (the `feed-vk-layer.zip` is Vulkan-only, unused).
+//! 3. DLSS5-Feeder — jlrouzies-fr/DLSS5-Feeder latest release zip only
+//!    (`dlss5-feed.addon64` + `DLSS5_Feed.fx`; `feed-vk-layer.zip` is Vulkan-only, unused).
+//!    No local overwrite of Feeder binaries or shaders — official release assets only.
 //! 4. LumeniteFX — umar-afzaal/LumeniteFX branch `mainline` (no releases):
 //!    Shaders/lumenite_*.fx, Shaders/include/*.fxh, Textures/lumenite_bluenoise256.png.
 //! 5. DLSS 5 add-on — RankFTW/rhi-repo releases: `renodx-dlss5-*` (renodx-dlss5.addon64),
 //!    `dlssnr-*` (nvngx_dlssnr.dll), `dlss-*` (nvngx_dlss.dll; not dlssg-/dlssd-).
 //! 6. ReShade.ini + ReShadePreset.ini: DLSS5_MV_PROVIDER=3, Lumenite_Kernel above DLSS5_Feed.
+//!    Optional LUMENITE: TRAA stays user-controlled; we soft-patch UI protect + preset defaults.
 
 use crate::game::{self, GameStatus};
 use crate::gpupref;
 use crate::net::{self, Progress};
+use crate::quality_preset::{self, QualityChoice, QualityOverrides, ResolvedQuality};
 use crate::renodx;
 use crate::reshade_ini;
 use anyhow::{anyhow, bail, Context, Result};
@@ -31,6 +38,239 @@ pub const RESHADE_SHADERS_RAW: &str =
 pub const FEEDER_REPO: &str = "jlrouzies-fr/DLSS5-Feeder";
 pub const LUMENITE_ZIP: &str =
     "https://codeload.github.com/umar-afzaal/LumeniteFX/zip/refs/heads/mainline";
+
+/// Official dgVoodoo 2.87.3 release zip (not bundled — downloaded into the game
+/// folder at Install time). License allows shipping individual DLLs with a
+/// game; forbids bundling inside launchers for general multi-app use.
+pub const DGVOODOO_TAG: &str = "v2.87.3";
+pub const DGVOODOO_ZIP: &str =
+    "https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.87.3/dgVoodoo2_87_3.zip";
+/// Zip members for D3D9 (32-bit Gothic-class vs rare 64-bit DX9).
+const DGVOODOO_D3D9_MEMBER_X86: &str = "MS/x86/D3D9.dll";
+const DGVOODOO_D3D9_MEMBER_X64: &str = "MS/x64/D3D9.dll";
+
+/// Minimum emulated VRAM (MB). Stock dgVoodoo is 256 — too low for Gothic 3 VH @ 1080p.
+const DGVOODOO_VRAM_FLOOR: u32 = 4096;
+/// Feeder/ReShade need D3D11; never leave `bestavailable` (may pick D3D12).
+const DGVOODOO_OUTPUT_API: &str = "d3d11_fl11_0";
+
+/// Full template used only when no `dgVoodoo.conf` exists yet.
+const DGVOODOO_CONF_TEMPLATE: &str = "\
+; Written by DLSS5oneclick — official dgVoodoo 2.87.3 (DX9 → D3D11 for ReShade dxgi.dll)
+; https://github.com/dege-diosg/dgVoodoo2/releases/tag/v2.87.3
+[General]
+OutputAPI = d3d11_fl11_0
+Adapters = all
+FullScreenOutput = default
+ScalingMode = unspecified
+[DirectX]
+VideoCard = internal3D
+VRAM = 4096
+Filtering = appdriven
+Mipmapping = appdriven
+Resolution = unforced
+Antialiasing = appdriven
+AppControlledScreenMode = true
+ForceVerticalSync = false
+dgVoodooWatermark = false
+FastVideoMemoryAccess = false
+[DirectXExt]
+RTTexturesForceScaleAndMSAA = false
+";
+
+/// Marker embedded in the Lumenite TRAA UI-protect patch (idempotent).
+const TRAA_UI_MARKER: &str = "DLSS5_TRAA_UI_PROTECT";
+const TRAA_FX: &str = "lumenite_TRAA.fx";
+
+/// Soft-patch installed `lumenite_TRAA.fx`: Geometric DLAA by default + skip temporal
+/// blend where `DLSS5_Mask` / HUD-like luma edges without depth structure say so.
+/// Leaves TRAA enabled/disabled as the user set it; only improves UI/text when on.
+fn apply_traa_ui_patch(game_dir: &Path) -> Result<Option<String>> {
+    let dest = game_dir
+        .join("reshade-shaders")
+        .join("Shaders")
+        .join(TRAA_FX);
+    if !dest.is_file() {
+        return Ok(None);
+    }
+    let mut text = fs::read_to_string(&dest)
+        .with_context(|| format!("reading {}", dest.display()))?;
+    if text.contains(TRAA_UI_MARKER) {
+        return Ok(Some(format!(
+            "reshade-shaders/Shaders/{TRAA_FX} (UI protect, already applied)"
+        )));
+    }
+
+    // Default Edge Detection → Geometric (stock tooltip already says it ignores flat UI).
+    let edge_anchor = "\"Geometric: silhouettes only, ignores flat UI.\";\n    > = 0;";
+    if !text.contains(edge_anchor) {
+        return Ok(Some(format!(
+            "reshade-shaders/Shaders/{TRAA_FX} (UI protect skipped: EDGE_MODE layout changed)"
+        )));
+    }
+    text = text.replace(
+        edge_anchor,
+        "\"Geometric: silhouettes only, ignores flat UI.\";\n    > = 1;",
+    );
+
+    let uniforms = r#"
+// DLSS5_TRAA_UI_PROTECT -- favour current frame on HUD/text (DLSS5oneclick)
+uniform bool UI_PROTECT <
+    ui_label = "Protect UI / text (skip temporal)";
+    ui_tooltip = "Lowers temporal blend where DLSS5_Mask distrusts motion, and where\n"
+                 "sharp luma edges lack geometric depth/normal structure (typical HUD/text).\n"
+                 "Needs Kernel above + DLSS 5 Feed above this effect for the bias mask.";
+> = true;
+
+uniform float UI_PROTECT_STRENGTH <
+    ui_type = "drag";
+    ui_min = 0.0; ui_max = 1.0; ui_step = 0.05;
+    ui_label = "UI protect strength";
+> = 1.0;
+
+"#;
+    let imports_anchor = "/*--------------.\n| :: IMPORTS :: |\n'--------------*/";
+    if !text.contains(imports_anchor) {
+        return Ok(Some(format!(
+            "reshade-shaders/Shaders/{TRAA_FX} (UI protect skipped: IMPORTS layout changed)"
+        )));
+    }
+    text = text.replace(imports_anchor, &format!("{uniforms}{imports_anchor}"));
+
+    let mask_tex = r#"
+// DLSS5_TRAA_UI_PROTECT -- same pooled mask Feed writes (bias-current-colour)
+texture DLSS5_Mask { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = R8; };
+sampler sDLSS5_Mask { Texture = DLSS5_Mask; MinFilter = POINT; MagFilter = POINT; MipFilter = POINT; };
+
+"#;
+    let ns_anchor = "namespace LumeniteTRAA {";
+    if !text.contains(ns_anchor) {
+        return Ok(Some(format!(
+            "reshade-shaders/Shaders/{TRAA_FX} (UI protect skipped: namespace layout changed)"
+        )));
+    }
+    text = text.replace(ns_anchor, &format!("{mask_tex}{ns_anchor}"));
+
+    let conf_anchor = "    confidence = saturate(confidence + 0.11 * 4.0 * confidence * (1.0 - confidence));\n\n    float2 historyUV = texcoord + flow;";
+    let conf_patch = r#"    confidence = saturate(confidence + 0.11 * 4.0 * confidence * (1.0 - confidence));
+
+    // DLSS5_TRAA_UI_PROTECT
+    if (UI_PROTECT)
+    {
+        float distrust = tex2Dlod(sDLSS5_Mask, float4(texcoord, 0.0, 0.0)).x;
+        float4 nPack = tex2Dlod(Kernel::sNormals, float4(texcoord, 0.0, 0.0));
+        float2 px = BUFFER_PIXEL_SIZE;
+        float dL = tex2Dlod(Kernel::sNormals, float4(texcoord - float2(px.x, 0.0), 0.0, 0.0)).a;
+        float dR = tex2Dlod(Kernel::sNormals, float4(texcoord + float2(px.x, 0.0), 0.0, 0.0)).a;
+        float dT = tex2Dlod(Kernel::sNormals, float4(texcoord - float2(0.0, px.y), 0.0, 0.0)).a;
+        float dB = tex2Dlod(Kernel::sNormals, float4(texcoord + float2(0.0, px.y), 0.0, 0.0)).a;
+        float depthEdge = abs(dL - dR) + abs(dT - dB);
+        float nEdge = length(nPack.xyz - tex2Dlod(Kernel::sNormals, float4(texcoord + float2(px.x, 0.0), 0.0, 0.0)).xyz);
+        float lumaEdge = abs(GetLuminance(samples[3]) - GetLuminance(samples[5]))
+                       + abs(GetLuminance(samples[1]) - GetLuminance(samples[7]));
+        // Sharp text/HUD edges without geometric structure
+        float uiHint = saturate(lumaEdge * 6.0) * (1.0 - saturate(depthEdge * 40.0 + nEdge * 4.0));
+        // Screen-space UI often gets camera/scene flow while depth stays flat
+        float mvPx = length(flow * float2(BUFFER_WIDTH, BUFFER_HEIGHT));
+        float badFlow = saturate(mvPx * 0.25) * (1.0 - saturate(depthEdge * 40.0));
+        float skip = saturate(max(max(distrust, uiHint), badFlow) * UI_PROTECT_STRENGTH);
+        confidence *= (1.0 - skip);
+    }
+
+    float2 historyUV = texcoord + flow;"#;
+    if !text.contains(conf_anchor) {
+        return Ok(Some(format!(
+            "reshade-shaders/Shaders/{TRAA_FX} (UI protect skipped: PS_TRAA layout changed)"
+        )));
+    }
+    text = text.replace(conf_anchor, conf_patch);
+
+    text = text.replace(
+        "ui_tooltip = \"Temporal Reprojection Anti-Aliasing.\";",
+        "ui_tooltip = \"Temporal Reprojection Anti-Aliasing.\\n\\n\
+Place BELOW DLSS 5 Feed. Edge Detection=Geometric + Protect UI/text reduce HUD smear.\\n\
+Uses DLSS5_Mask from Feed when present (DLSS5oneclick UI protect patch).\";",
+    );
+
+    fs::write(&dest, text).with_context(|| format!("writing patched {}", dest.display()))?;
+    Ok(Some(format!(
+        "reshade-shaders/Shaders/{TRAA_FX} (UI protect patch)"
+    )))
+}
+
+const VULKAN_SETUP_TXT: &str = "\
+DLSS5oneclick — Vulkan Feeder kit (manual finish)
+================================================
+This tool does NOT register ReShade as a Vulkan layer (that is why full
+Install is refused). Files copied here still need ReShade's own setup.
+
+1. Run ReShade Setup → select this game exe → choose Vulkan → Addon support.
+2. In ReShade.ini next to the exe, under [ADDON]:
+     AddonPath=<this folder>
+3. Ensure dlss5-feed.addon64 and reshade-shaders/Shaders/DLSS5_Feed.fx are here
+   (already copied by «Copy Vulkan Feeder kit»).
+4. Also place a neural consumer (renodx-dlss5.addon64 + nvngx_dlssnr.dll) as for
+   a 64-bit D3D game, or use Deep Fried Chicken per Feeder docs.
+5. If dlss5-feed.log reports missing interop entry points, start the game via
+   run-with-feed-layer.bat from the DLSS5-Feeder repo layer/ folder.
+
+Do not expect dxgi.dll from this tool to load under Vulkan.
+";
+
+/// Drop Feeder addon + FX + setup note for manual Vulkan ReShade (no layer install).
+/// Fetches the official DLSS5-Feeder release zip — never a bundled/modified add-on.
+pub fn copy_vulkan_feeder_kit(game_dir: &Path) -> Result<Vec<String>> {
+    let client = net::client()?;
+    let tag = match net::latest_tag(&client, FEEDER_REPO) {
+        Ok(t) => t,
+        Err(_) => net::github_release_tags_html(&client, FEEDER_REPO, "v", 1)?
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow!("no DLSS5-Feeder release found"))?,
+    };
+    let url = net::github_asset_url_html(&client, FEEDER_REPO, &tag, r#"[^"]+\.zip"#)?;
+    let work = tempfile::tempdir()?;
+    let zip_path = work.path().join("dlss5-feeder.zip");
+    net::download(&client, &url, &zip_path, "DLSS5-Feeder", &|_, _| {})?;
+    copy_vulkan_feeder_kit_from_zip(&zip_path, game_dir, &tag)
+}
+
+/// Extract official Feeder addon + FX from a release zip (testable offline).
+pub fn copy_vulkan_feeder_kit_from_zip(
+    zip_path: &Path,
+    game_dir: &Path,
+    tag: &str,
+) -> Result<Vec<String>> {
+    let f = fs::File::open(zip_path)?;
+    let mut zip = zip::ZipArchive::new(f).context("DLSS5-Feeder download is not a valid zip")?;
+    let members: Vec<String> = zip.file_names().map(str::to_owned).collect();
+    let pick = |want: &str| -> Option<String> {
+        members
+            .iter()
+            .find(|m| net::file_name(&m.replace('\\', "/")).eq_ignore_ascii_case(want))
+            .cloned()
+    };
+    let addon = pick(game::FEEDER_ADDON)
+        .ok_or_else(|| anyhow!("DLSS5-Feeder {tag} has no {}", game::FEEDER_ADDON))?;
+    let fx = pick(game::FEEDER_FX)
+        .ok_or_else(|| anyhow!("DLSS5-Feeder {tag} has no {}", game::FEEDER_FX))?;
+    net::extract_member(&mut zip, &addon, &game_dir.join(game::FEEDER_ADDON))?;
+    net::extract_member(
+        &mut zip,
+        &fx,
+        &game_dir
+            .join("reshade-shaders")
+            .join("Shaders")
+            .join(game::FEEDER_FX),
+    )?;
+    let note = game_dir.join("VULKAN-SETUP.txt");
+    fs::write(&note, VULKAN_SETUP_TXT).with_context(|| format!("writing {}", note.display()))?;
+    Ok(vec![
+        format!("{} ({tag})", game::FEEDER_ADDON),
+        format!("reshade-shaders/Shaders/{}", game::FEEDER_FX),
+        "VULKAN-SETUP.txt".into(),
+    ])
+}
 
 /// Which install engine carries the DLSS 5 pass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -76,6 +316,72 @@ impl Latest {
             dlssnr: rhi_latest(client, "dlssnr-").ok().map(|(t, _)| t),
         }
     }
+}
+
+
+/// Files that must exist after a successful Feeder/Native install.
+/// Used so the UI never says "Everything is in place" on a partial copy.
+pub fn missing_install_files(st: &GameStatus) -> Vec<String> {
+    let mut missing = Vec::new();
+    match st.mode {
+        game::Mode::Feeder => {
+            if !st.reshade {
+                missing.push(format!("{} (ReShade)", game::RESHADE_PROXY));
+            }
+            if !st.headers {
+                missing.push("reshade-shaders/Shaders headers (ReShade.fxh…)".into());
+            }
+            if !st.feeder {
+                let addon = if st.is32() {
+                    game::FEEDER_ADDON32
+                } else {
+                    game::FEEDER_ADDON
+                };
+                missing.push(format!("{addon} / {}", game::FEEDER_FX));
+            }
+            if !st.lumenite {
+                missing.push("LumeniteFX shaders".into());
+            }
+            if !st.dlss5_addon && !st.upstream {
+                missing.push("DLSS 5 neural consumer add-on".into());
+            }
+            if !st.dlssnr {
+                missing.push(game::DLSSNR_DLL.into());
+            }
+            if !st.dlss {
+                missing.push(game::DLSS_DLL.into());
+            }
+            if st.is32() {
+                if !st.host_exe {
+                    missing.push(format!("{}/{}", game::HOST_DIR, game::HOST_EXE));
+                }
+                if !st.host_reshade {
+                    missing.push(format!("{}/{}", game::HOST_DIR, game::RESHADE_PROXY));
+                }
+            }
+        }
+        game::Mode::Native => {
+            if st.opti {
+                if !st.dlssnr {
+                    missing.push(game::DLSSNR_DLL.into());
+                }
+            } else {
+                if !st.reshade {
+                    missing.push(format!("{} (ReShade)", game::RESHADE_PROXY));
+                }
+                if !(st.dlss5_addon || st.upstream) {
+                    missing.push("DLSS 5 neural consumer add-on".into());
+                }
+                if !st.dlssnr {
+                    missing.push(game::DLSSNR_DLL.into());
+                }
+                if st.needs_bridge() && !st.bridge {
+                    missing.push("dx11 bridge add-on".into());
+                }
+            }
+        }
+    }
+    missing
 }
 
 /// Components this tool placed in `dir` whose recorded version is behind
@@ -331,6 +637,10 @@ pub struct Step {
 const STEP_RESHADE: Step = Step {
     name: "ReShade (add-on build)",
     run: step_reshade,
+};
+const STEP_DGVOODOO: Step = Step {
+    name: "dgVoodoo 2.87.3 (DX9 → D3D11)",
+    run: step_dgvoodoo,
 };
 const STEP_HEADERS: Step = Step {
     name: "ReShade shader headers",
@@ -609,6 +919,13 @@ pub fn plan_with(st: &GameStatus, engine: Engine, with_renodx: bool, upstream: b
     if st.re_engine {
         v.insert(0, STEP_REFRAMEWORK);
     }
+    // DX9 never loads dxgi.dll; dgVoodoo must sit in the game folder first.
+    // Always run on Dx9 (even when the DLL is already present) so Install can
+    // refresh dgVoodoo.conf — Uninstall never removes dgVoodoo, and a bare
+    // OutputAPI-only conf leaves stock VRAM=256 (Gothic 3 texture failures).
+    if st.api == game::Api::Dx9 {
+        v.insert(0, STEP_DGVOODOO);
+    }
     v.push(STEP_GPU_PREF);
     v
 }
@@ -757,6 +1074,261 @@ pub fn install_reshade_from_setup(
     net::extract_member(&mut zip, dll, &game_dir.join(dest_name))
         .with_context(|| format!("{} does not contain {dll}", setup_exe.display()))?;
     Ok(vec![dest_name.into()])
+}
+
+/// Parse a loose dgVoodoo-style INI and ensure Feeder-safe keys without wiping CPL settings.
+/// - Force `OutputAPI = d3d11_fl11_0` under `[General]`
+/// - Floor `VRAM` under `[DirectX]` to at least [`DGVOODOO_VRAM_FLOOR`]
+/// - Create missing sections/keys; leave every other line untouched
+fn merge_dgvoodoo_conf(existing: &str) -> String {
+    let mut out = String::with_capacity(existing.len() + 128);
+    let mut section = String::new();
+    let mut saw_general = false;
+    let mut saw_directx = false;
+    let mut output_api_set = false;
+    let mut vram_set = false;
+    let mut watermark_set = false;
+
+    for raw in existing.lines() {
+        let line = raw.trim_end();
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') && trimmed.len() >= 2 {
+            // Flush required keys before leaving a section.
+            if section.eq_ignore_ascii_case("General") && !output_api_set {
+                out.push_str(&format!("OutputAPI = {DGVOODOO_OUTPUT_API}\n"));
+                output_api_set = true;
+            }
+            if section.eq_ignore_ascii_case("DirectX") {
+                if !vram_set {
+                    out.push_str(&format!("VRAM = {DGVOODOO_VRAM_FLOOR}\n"));
+                    vram_set = true;
+                }
+                if !watermark_set {
+                    out.push_str("dgVoodooWatermark = false\n");
+                    watermark_set = true;
+                }
+            }
+            section = trimmed[1..trimmed.len() - 1].to_string();
+            if section.eq_ignore_ascii_case("General") {
+                saw_general = true;
+            }
+            if section.eq_ignore_ascii_case("DirectX") {
+                saw_directx = true;
+            }
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+
+        if let Some((k, v)) = trimmed.split_once('=') {
+            let key = k.trim();
+            let val = v.trim();
+            if section.eq_ignore_ascii_case("General") && key.eq_ignore_ascii_case("OutputAPI") {
+                out.push_str(&format!("OutputAPI = {DGVOODOO_OUTPUT_API}\n"));
+                output_api_set = true;
+                continue;
+            }
+            if section.eq_ignore_ascii_case("DirectX") && key.eq_ignore_ascii_case("VRAM") {
+                let cur = val
+                    .split_whitespace()
+                    .next()
+                    .and_then(|s| s.parse::<u32>().ok())
+                    .unwrap_or(0);
+                let floor = cur.max(DGVOODOO_VRAM_FLOOR);
+                out.push_str(&format!("VRAM = {floor}\n"));
+                vram_set = true;
+                continue;
+            }
+            if section.eq_ignore_ascii_case("DirectX") && key.eq_ignore_ascii_case("dgVoodooWatermark") {
+                out.push_str("dgVoodooWatermark = false\n");
+                watermark_set = true;
+                continue;
+            }
+        }
+
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    if section.eq_ignore_ascii_case("General") && !output_api_set {
+        out.push_str(&format!("OutputAPI = {DGVOODOO_OUTPUT_API}\n"));
+        output_api_set = true;
+    }
+    if section.eq_ignore_ascii_case("DirectX") {
+        if !vram_set {
+            out.push_str(&format!("VRAM = {DGVOODOO_VRAM_FLOOR}\n"));
+            vram_set = true;
+        }
+        if !watermark_set {
+            out.push_str("dgVoodooWatermark = false\n");
+            watermark_set = true;
+        }
+    }
+
+    if !saw_general {
+        out.push_str("\n[General]\n");
+        out.push_str(&format!("OutputAPI = {DGVOODOO_OUTPUT_API}\n"));
+        output_api_set = true;
+    } else if !output_api_set {
+        // Section existed but key never appeared (empty section mid-file already handled).
+        out.push_str(&format!("OutputAPI = {DGVOODOO_OUTPUT_API}\n"));
+    }
+
+    if !saw_directx {
+        out.push_str("\n[DirectX]\n");
+        out.push_str("VideoCard = internal3D\n");
+        out.push_str(&format!("VRAM = {DGVOODOO_VRAM_FLOOR}\n"));
+        out.push_str("dgVoodooWatermark = false\n");
+        out.push_str("Antialiasing = appdriven\n");
+        out.push_str("FastVideoMemoryAccess = false\n");
+    } else {
+        if !vram_set {
+            out.push_str(&format!("VRAM = {DGVOODOO_VRAM_FLOOR}\n"));
+        }
+        if !watermark_set {
+            out.push_str("dgVoodooWatermark = false\n");
+        }
+    }
+
+    let _ = (output_api_set, vram_set);
+    out
+}
+
+fn assert_dgvoodoo_conf_healthy(text: &str) -> Result<()> {
+    let lower = text.to_ascii_lowercase();
+    if !lower.contains("outputapi") || !lower.contains("d3d11_fl11_0") {
+        bail!("dgVoodoo.conf health check failed: OutputAPI must be d3d11_fl11_0");
+    }
+    // Find VRAM value
+    let mut vram_ok = false;
+    let mut section = "";
+    for line in text.lines() {
+        let t = line.trim();
+        if t.starts_with('[') && t.ends_with(']') {
+            section = t;
+            continue;
+        }
+        if section.eq_ignore_ascii_case("[DirectX]") {
+            if let Some((k, v)) = t.split_once('=') {
+                if k.trim().eq_ignore_ascii_case("VRAM") {
+                    let n = v
+                        .split_whitespace()
+                        .next()
+                        .and_then(|s| s.parse::<u32>().ok())
+                        .unwrap_or(0);
+                    vram_ok = n >= DGVOODOO_VRAM_FLOOR;
+                }
+            }
+        }
+    }
+    if !vram_ok {
+        bail!(
+            "dgVoodoo.conf health check failed: VRAM must be >= {DGVOODOO_VRAM_FLOOR}"
+        );
+    }
+    Ok(())
+}
+
+/// Smart-merge (or create) `dgVoodoo.conf`: force OutputAPI, floor VRAM, preserve the rest.
+/// Writes `dgVoodoo.conf.bak` once before the first edit of an existing file.
+pub fn write_dgvoodoo_conf(game_dir: &Path) -> Result<()> {
+    let conf = game_dir.join("dgVoodoo.conf");
+    let bak = game_dir.join("dgVoodoo.conf.bak");
+    let text = if conf.is_file() {
+        let existing = fs::read_to_string(&conf)
+            .with_context(|| format!("reading {}", conf.display()))?;
+        if !bak.is_file() {
+            fs::write(&bak, &existing)
+                .with_context(|| format!("writing {}", bak.display()))?;
+        }
+        merge_dgvoodoo_conf(&existing)
+    } else {
+        DGVOODOO_CONF_TEMPLATE.to_string()
+    };
+    assert_dgvoodoo_conf_healthy(&text)?;
+    fs::write(&conf, text).with_context(|| format!("writing {}", conf.display()))?;
+    Ok(())
+}
+
+fn dgvoodoo_d3d9_member(bitness: u8) -> &'static str {
+    if bitness == 64 {
+        DGVOODOO_D3D9_MEMBER_X64
+    } else {
+        DGVOODOO_D3D9_MEMBER_X86
+    }
+}
+
+/// Place official dgVoodoo `MS/{x86|x64}/D3D9.dll` + smart-merged conf in the game folder.
+/// Never restores `d3d9.dll.off` (old ReShade); always extracts from the release zip.
+pub fn install_dgvoodoo_from_zip(
+    zip_path: &Path,
+    game_dir: &Path,
+    bitness: u8,
+) -> Result<Vec<String>> {
+    let want = dgvoodoo_d3d9_member(bitness);
+    let f = fs::File::open(zip_path)?;
+    let mut zip = zip::ZipArchive::new(f).context("dgVoodoo download is not a valid zip")?;
+    let member = zip
+        .file_names()
+        .find(|n| {
+            let norm = n.replace('\\', "/");
+            norm.eq_ignore_ascii_case(want)
+                || (bitness != 64
+                    && norm.to_ascii_lowercase().ends_with("/ms/x86/d3d9.dll"))
+                || (bitness == 64
+                    && norm.to_ascii_lowercase().ends_with("/ms/x64/d3d9.dll"))
+        })
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            anyhow!("dgVoodoo zip does not contain {want} — unexpected release layout")
+        })?;
+    let dest = game_dir.join("d3d9.dll");
+    // Refuse to clobber a foreign wrapper; callers should have blocked Install already.
+    if dest.is_file() && !game::is_dgvoodoo(game_dir) {
+        bail!(
+            "a d3d9.dll that is not dgVoodoo is already present; remove or replace it, then Install again"
+        );
+    }
+    net::extract_member(&mut zip, &member, &dest)?;
+    write_dgvoodoo_conf(game_dir)?;
+    if !game::is_dgvoodoo(game_dir) {
+        bail!("wrote d3d9.dll + dgVoodoo.conf but dgVoodoo was not detected afterward");
+    }
+    Ok(vec!["d3d9.dll".into(), "dgVoodoo.conf".into()])
+}
+
+fn step_dgvoodoo(
+    client: &Client,
+    st: &GameStatus,
+    work: &Path,
+    progress: Progress,
+) -> Result<Vec<String>> {
+    let d = st.game_dir();
+    let mut out: Vec<String> = Vec::new();
+    let member = dgvoodoo_d3d9_member(st.bitness);
+    if game::is_dgvoodoo(d) {
+        progress(50, "dgVoodoo DLL present — merging conf");
+    } else {
+        // Do not treat d3d9.dll.off (old ReShade) as dgVoodoo — download the real DLL.
+        if d.join("d3d9.dll").is_file() {
+            bail!(
+                "a d3d9.dll that is not dgVoodoo is already present; remove or replace it with \
+                 dgVoodoo 2.87.3 ({member}), then Install again"
+            );
+        }
+        progress(0, &format!("Downloading dgVoodoo {DGVOODOO_TAG}"));
+        let z = work.join("dgVoodoo2_87_3.zip");
+        net::download(client, DGVOODOO_ZIP, &z, "dgVoodoo 2.87.3", progress)?;
+        progress(90, &format!("Extracting {member}"));
+        out.extend(install_dgvoodoo_from_zip(&z, d, st.bitness)?);
+        progress(100, "dgVoodoo 2.87.3 ready");
+        return Ok(out);
+    }
+    // DLL already there: merge conf so VRAM/OutputAPI stay safe without wiping CPL.
+    write_dgvoodoo_conf(d)?;
+    out.push("dgVoodoo.conf (OutputAPI/VRAM merged)".into());
+    progress(100, "dgVoodoo conf merged");
+    Ok(out)
 }
 
 fn step_reshade(
@@ -965,6 +1537,9 @@ pub fn install_lumenite_from_zip(zip_path: &Path, game_dir: &Path) -> Result<Vec
             installed.push(format!("{rel}/{name}"));
         }
     }
+    if let Some(msg) = apply_traa_ui_patch(game_dir)? {
+        installed.push(msg);
+    }
     Ok(installed)
 }
 
@@ -976,7 +1551,11 @@ fn step_lumenite(
 ) -> Result<Vec<String>> {
     if st.lumenite {
         progress(100, "LumeniteFX already installed");
-        return Ok(vec![]);
+        let mut out = vec![];
+        if let Some(msg) = apply_traa_ui_patch(st.game_dir())? {
+            out.push(msg);
+        }
+        return Ok(out);
     }
     let z = work.join("LumeniteFX.zip");
     net::download(client, LUMENITE_ZIP, &z, "LumeniteFX", progress)?;
@@ -1229,6 +1808,27 @@ fn step_upstream(
     Ok(vec![game::UPSTREAM_ADDON.into()])
 }
 
+/// Active quality resolution for the install currently running (set by `run_all_with`).
+static INSTALL_QUALITY: std::sync::Mutex<Option<ResolvedQuality>> = std::sync::Mutex::new(None);
+
+fn install_quality() -> ResolvedQuality {
+    INSTALL_QUALITY
+        .lock()
+        .ok()
+        .and_then(|g| g.clone())
+        .unwrap_or_else(quality_preset::fallback_medium)
+}
+
+pub fn write_feeder_cfg(game_dir: &Path, r: &ResolvedQuality) -> Result<()> {
+    let path = game_dir.join("dlss5-feed.cfg");
+    let mut text = quality_preset::feeder_cfg_text(r);
+    // Overlay UX defaults from Settings (log_detail / evaluate_stride / …).
+    let settings = crate::settings::Settings::load();
+    text = crate::settings::apply_overlay_to_cfg(&text, &settings);
+    fs::write(&path, text).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
 // ── step 6: config ─────────────────────────────────────────────────
 
 fn step_config(_c: &Client, st: &GameStatus, _w: &Path, progress: Progress) -> Result<Vec<String>> {
@@ -1238,9 +1838,21 @@ fn step_config(_c: &Client, st: &GameStatus, _w: &Path, progress: Progress) -> R
         progress(100, "ReShade.ini written");
         return Ok(vec![game::RESHADE_INI.into()]);
     }
-    reshade_ini::write_preset(st.game_dir())?;
-    progress(100, "ReShade.ini + ReShadePreset.ini written");
-    Ok(vec![game::RESHADE_INI.into(), game::RESHADE_PRESET.into()])
+    let q = install_quality();
+    reshade_ini::write_preset(st.game_dir(), q.enable_lumenite)?;
+    reshade_ini::write_feed_fx_uniforms(st.game_dir(), &quality_preset::feed_fx_uniforms(&q))?;
+    reshade_ini::write_traa_ui_defaults(st.game_dir())?;
+    write_feeder_cfg(st.game_dir(), &q)?;
+    let mut out = vec![
+        game::RESHADE_INI.into(),
+        game::RESHADE_PRESET.into(),
+        "dlss5-feed.cfg".into(),
+    ];
+    progress(100, "ReShade + feeder defaults (Optimize on first attach)");
+    if let Some(msg) = apply_traa_ui_patch(st.game_dir())? {
+        out.push(msg);
+    }
+    Ok(out)
 }
 
 // ── step 7: which GPU Windows starts the process on ────────────
@@ -1290,11 +1902,29 @@ pub enum StepState {
     Error,
 }
 
+/// Quality seed for an install (Settings page / CLI).
+#[derive(Debug, Clone)]
+pub struct InstallOpts {
+    pub quality: QualityChoice,
+    pub overrides: QualityOverrides,
+}
+
+impl Default for InstallOpts {
+    fn default() -> Self {
+        let s = crate::settings::Settings::load();
+        Self {
+            quality: s.quality_choice(),
+            overrides: s.quality_overrides(),
+        }
+    }
+}
+
 pub fn run_all_with(
     exe: &Path,
     engine: Engine,
     with_renodx: bool,
     upstream: bool,
+    opts: InstallOpts,
     progress: Progress,
     step_cb: &(dyn Fn(usize, usize, &str, StepState, &str) + Sync),
 ) -> Result<Vec<(String, Vec<String>)>> {
@@ -1323,6 +1953,10 @@ pub fn run_all_with(
              reads the inputs the game hands to DLSS). This game has none — use the ReShade engine."
         );
     }
+    let resolved = quality_preset::resolve(opts.quality, &st, &opts.overrides);
+    if let Ok(mut slot) = INSTALL_QUALITY.lock() {
+        *slot = Some(resolved);
+    }
     let client = net::client()?;
     let work = tempfile::Builder::new()
         .prefix("dlss5oneclick-")
@@ -1345,12 +1979,52 @@ pub fn run_all_with(
             Err(e) => {
                 let msg = format!("{e:#}");
                 step_cb(i, n, step.name, StepState::Error, &msg);
+                if let Ok(mut slot) = INSTALL_QUALITY.lock() {
+                    *slot = None;
+                }
                 return Err(anyhow!("{}: {msg}", step.name));
             }
         }
         st = game::inspect(exe)?;
     }
+    if let Ok(mut slot) = INSTALL_QUALITY.lock() {
+        *slot = None;
+    }
+    // Re-inspect and refuse a hollow "success" when critical files are missing.
+    st = game::inspect(exe)?;
+    let missing = missing_install_files(&st);
+    if !missing.is_empty() {
+        bail!(
+            "Install finished but files are missing: {}. Not reporting success.",
+            missing.join(", ")
+        );
+    }
     Ok(results)
+}
+
+/// Convenience wrapper used by CLI / GUI when no explicit quality is passed —
+/// reads `%LOCALAPPDATA%\dlss5oneclick\settings.json` for defaults.
+pub fn run_all(
+    exe: &Path,
+    engine: Engine,
+    with_renodx: bool,
+    upstream: bool,
+    progress: Progress,
+    step_cb: &(dyn Fn(usize, usize, &str, StepState, &str) + Sync),
+) -> Result<Vec<(String, Vec<String>)>> {
+    let s = crate::settings::Settings::load();
+    run_all_with(
+        exe,
+        engine,
+        with_renodx,
+        upstream,
+        InstallOpts {
+            quality: s.quality_choice(),
+            overrides: s.quality_overrides(),
+        },
+        progress,
+        step_cb,
+    )
 }
 
 /// Remove everything this tool places except ReShade itself and nvngx_dlss.dll.
@@ -1464,53 +2138,36 @@ pub fn uninstall(exe: &Path) -> Result<Vec<String>> {
     Ok(removed)
 }
 
-/// `uninstall`, then ReShade itself — but only when nothing foreign remains.
+/// `uninstall`, then ReShade itself (`dxgi.dll` + ini/logs).
 ///
-/// Refuses to touch ReShade when, after removing this tool's files, the game
-/// still has other `.addon64`/`.addon32` files or other shaders in
-/// `reshade-shaders` — that is somebody's own ReShade setup. `dxgi.dll` is
-/// only deleted when it verifiably is a ReShade DLL. Returns
-/// `(removed, kept_reason)`; `kept_reason` is `Some` when ReShade was left.
+/// Refuses only when a foreign `.addon64`/`.addon32` remains — those need
+/// ReShade to load. Leftover shaders under `reshade-shaders` (common on older
+/// packs, e.g. Gothic 3) no longer block removal: this tool always installs
+/// ReShade as `dxgi.dll`, never as `d3d9.dll`, and never deletes dgVoodoo's
+/// `d3d9.dll` / `dgVoodoo.conf`. `dxgi.dll` is only deleted when it
+/// verifiably is a ReShade DLL. Returns `(removed, kept_reason)`;
+/// `kept_reason` is `Some` when ReShade was left.
 pub fn uninstall_all(exe: &Path) -> Result<(Vec<String>, Option<String>)> {
     let mut removed = uninstall(exe)?;
     let d = exe.parent().context("exe has no parent")?;
 
-    let mut foreign: Vec<String> = Vec::new();
+    let mut foreign_addons: Vec<String> = Vec::new();
     if let Ok(rd) = fs::read_dir(d) {
         for e in rd.flatten() {
             let n = e.file_name().to_string_lossy().to_lowercase();
             if n.ends_with(".addon64") || n.ends_with(".addon32") {
-                foreign.push(n);
+                foreign_addons.push(n);
             }
         }
     }
-    let shaders_root = d.join("reshade-shaders");
-    let mut walk = vec![shaders_root.clone()];
-    while let Some(dir) = walk.pop() {
-        if let Ok(rd) = fs::read_dir(&dir) {
-            for e in rd.flatten() {
-                let p = e.path();
-                if p.is_dir() {
-                    walk.push(p);
-                } else {
-                    foreign.push(
-                        p.strip_prefix(d)
-                            .unwrap_or(&p)
-                            .to_string_lossy()
-                            .replace('\\', "/"),
-                    );
-                }
-            }
-        }
-    }
-    if !foreign.is_empty() {
-        foreign.sort();
-        foreign.truncate(6);
+    if !foreign_addons.is_empty() {
+        foreign_addons.sort();
+        foreign_addons.truncate(6);
         return Ok((
             removed,
             Some(format!(
-                "ReShade left in place: the game still has files this tool did not install ({})",
-                foreign.join(", ")
+                "ReShade left in place: the game still has add-ons this tool did not install ({})",
+                foreign_addons.join(", ")
             )),
         ));
     }
@@ -1544,9 +2201,34 @@ pub fn uninstall_all(exe: &Path) -> Result<(Vec<String>, Option<String>)> {
             }
         }
     }
+    let shaders_root = d.join("reshade-shaders");
+    let mut leftover_shaders = false;
+    let mut walk = vec![shaders_root.clone()];
+    while let Some(dir) = walk.pop() {
+        if let Ok(rd) = fs::read_dir(&dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk.push(p);
+                } else {
+                    leftover_shaders = true;
+                    break;
+                }
+            }
+        }
+        if leftover_shaders {
+            break;
+        }
+    }
     if shaders_root.is_dir() {
-        fs::remove_dir_all(&shaders_root)?;
-        removed.push("reshade-shaders/".into());
+        if leftover_shaders {
+            removed.push(
+                "reshade-shaders/ (left: shaders this tool did not install)".into(),
+            );
+        } else {
+            fs::remove_dir_all(&shaders_root)?;
+            removed.push("reshade-shaders/".into());
+        }
     }
     Ok((removed, None))
 }
@@ -1608,6 +2290,160 @@ mod tests {
     }
 
     #[test]
+    fn vulkan_feeder_kit_writes_addon_fx_and_note() {
+        let t = tempfile::tempdir().unwrap();
+        let d = t.path();
+        let z = t.path().join("feeder.zip");
+        write_zip(
+            &z,
+            &[
+                (game::FEEDER_ADDON, b"addon"),
+                (game::FEEDER_FX, b"fx"),
+            ],
+            &[],
+        );
+        let out = copy_vulkan_feeder_kit_from_zip(&z, d, "v0.14.0").unwrap();
+        assert!(d.join(game::FEEDER_ADDON).is_file());
+        assert!(d
+            .join("reshade-shaders")
+            .join("Shaders")
+            .join(game::FEEDER_FX)
+            .is_file());
+        assert!(d.join("VULKAN-SETUP.txt").is_file());
+        assert!(out.iter().any(|s| s.contains("VULKAN-SETUP")));
+        assert!(out.iter().any(|s| s.contains("v0.14.0")));
+    }
+
+    #[test]
+    fn dgvoodoo_from_zip_writes_d3d9_and_conf_ignores_off() {
+        let t = tempfile::tempdir().unwrap();
+        let d = t.path();
+        // Old ReShade rename must not be restored as dgVoodoo.
+        fs::write(d.join("d3d9.dll.off"), b"MZ old reshade not dgVoodoo").unwrap();
+        let z = d.join("dgVoodoo2_87_3.zip");
+        write_zip(
+            &z,
+            &[(
+                "MS/x86/D3D9.dll",
+                b"MZ....dgVoodoo2 wrapper bytes for detect....",
+            )],
+            &[],
+        );
+        let out = install_dgvoodoo_from_zip(&z, d, 32).unwrap();
+        assert!(out.contains(&"d3d9.dll".to_string()));
+        assert!(out.contains(&"dgVoodoo.conf".to_string()));
+        let dll = fs::read(d.join("d3d9.dll")).unwrap();
+        assert!(dll.windows(8).any(|w| w.eq_ignore_ascii_case(b"dgVoodoo")));
+        assert_ne!(
+            fs::read(d.join("d3d9.dll.off")).unwrap(),
+            dll,
+            "must not restore d3d9.dll.off"
+        );
+        let conf = fs::read_to_string(d.join("dgVoodoo.conf")).unwrap();
+        assert!(conf.contains("OutputAPI = d3d11_fl11_0"));
+        assert!(conf.contains("VRAM = 4096"));
+        assert!(conf.contains("Antialiasing = appdriven"));
+        assert!(conf.contains("FastVideoMemoryAccess = false"));
+        assert!(game::is_dgvoodoo(d));
+    }
+
+    #[test]
+    fn dgvoodoo_conf_merge_preserves_user_keys_and_floors_vram() {
+        let t = tempfile::tempdir().unwrap();
+        let d = t.path();
+        fs::write(
+            d.join("dgVoodoo.conf"),
+            "[General]\nOutputAPI = bestavailable\nAdapters = all\n\
+             [DirectX]\nVRAM = 256\nFiltering = force16bit\n",
+        )
+        .unwrap();
+        write_dgvoodoo_conf(d).unwrap();
+        assert!(d.join("dgVoodoo.conf.bak").is_file());
+        let conf = fs::read_to_string(d.join("dgVoodoo.conf")).unwrap();
+        assert!(conf.contains("OutputAPI = d3d11_fl11_0"));
+        assert!(!conf.to_ascii_lowercase().contains("bestavailable"));
+        assert!(conf.contains("VRAM = 4096"));
+        assert!(conf.contains("Filtering = force16bit"));
+        assert!(conf.contains("Adapters = all"));
+        // Second merge must not overwrite bak with already-merged text.
+        let bak1 = fs::read(d.join("dgVoodoo.conf.bak")).unwrap();
+        write_dgvoodoo_conf(d).unwrap();
+        assert_eq!(fs::read(d.join("dgVoodoo.conf.bak")).unwrap(), bak1);
+        // Keep a higher user VRAM.
+        fs::write(
+            d.join("dgVoodoo.conf"),
+            "[General]\nOutputAPI = d3d11_fl11_0\n[DirectX]\nVRAM = 8192\n",
+        )
+        .unwrap();
+        write_dgvoodoo_conf(d).unwrap();
+        let conf2 = fs::read_to_string(d.join("dgVoodoo.conf")).unwrap();
+        assert!(conf2.contains("VRAM = 8192"));
+    }
+
+    #[test]
+    fn dgvoodoo_from_zip_picks_x64_member() {
+        let t = tempfile::tempdir().unwrap();
+        let d = t.path();
+        let z = d.join("dgVoodoo2_87_3.zip");
+        write_zip(
+            &z,
+            &[(
+                "MS/x64/D3D9.dll",
+                b"MZ....dgVoodoo2 wrapper bytes for detect....",
+            )],
+            &[],
+        );
+        install_dgvoodoo_from_zip(&z, d, 64).unwrap();
+        assert!(game::is_dgvoodoo(d));
+    }
+
+    #[test]
+    fn plan_puts_dgvoodoo_first_for_dx9() {
+        let t = tempfile::tempdir().unwrap();
+        let exe = make_pe_with_imports(&t.path().join("g3.exe"), game::PE_X86, &["engine.dll"]);
+        make_pe_with_imports(
+            &t.path().join("Engine.dll"),
+            game::PE_X86,
+            &["d3d9.dll", "kernel32.dll"],
+        );
+        std::env::set_var("DLSS5ONECLICK_SKIP_GPU_CHECK", "1");
+        let st = game::inspect(&exe).unwrap();
+        assert!(st.needs_dgvoodoo());
+        let names: Vec<&str> = plan_with(&st, Engine::ReShade, false, false)
+            .iter()
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(names[0], "dgVoodoo 2.87.3 (DX9 → D3D11)");
+        assert!(names.iter().any(|n| n.starts_with("ReShade")));
+    }
+
+    #[test]
+    fn plan_refreshes_dgvoodoo_conf_when_already_present() {
+        let t = tempfile::tempdir().unwrap();
+        let d = t.path();
+        let exe = make_pe_with_imports(&d.join("g3.exe"), game::PE_X86, &["engine.dll"]);
+        make_pe_with_imports(
+            &d.join("Engine.dll"),
+            game::PE_X86,
+            &["d3d9.dll", "kernel32.dll"],
+        );
+        fs::write(d.join("d3d9.dll"), b"MZ...dgVoodoo2 wrapper...").unwrap();
+        fs::write(
+            d.join("dgVoodoo.conf"),
+            b"[General]\nOutputAPI = bestavailable\n",
+        )
+        .unwrap();
+        std::env::set_var("DLSS5ONECLICK_SKIP_GPU_CHECK", "1");
+        let st = game::inspect(&exe).unwrap();
+        assert!(!st.needs_dgvoodoo());
+        let names: Vec<&str> = plan_with(&st, Engine::ReShade, false, false)
+            .iter()
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(names[0], "dgVoodoo 2.87.3 (DX9 → D3D11)");
+    }
+
+    #[test]
     fn reshade_from_setup_exe_with_prepended_stub() {
         let t = tempfile::tempdir().unwrap();
         let exe = make_pe(&t.path().join("game.exe"), game::PE_X64);
@@ -1654,7 +2490,10 @@ mod tests {
             &[],
         );
         let installed = install_lumenite_from_zip(&z, t.path()).unwrap();
-        assert_eq!(installed.len(), 4);
+        assert!(
+            installed.len() >= 4,
+            "expected at least Kernel/TRAA/include/png, got {installed:?}"
+        );
         assert!(t
             .path()
             .join("reshade-shaders/Shaders/lumenite_Kernel.fx")
@@ -1674,6 +2513,43 @@ mod tests {
         write_zip(&bad, &[("whatever.txt", b"x")], &[]);
         assert!(install_lumenite_from_zip(&bad, t.path()).is_err());
     }
+
+    #[test]
+    fn traa_ui_protect_patch_is_idempotent() {
+        let t = tempfile::tempdir().unwrap();
+        let shaders = t.path().join("reshade-shaders").join("Shaders");
+        fs::create_dir_all(&shaders).unwrap();
+        // Anchors must match stock lumenite_TRAA.fx (LumeniteFX mainline).
+        let body = concat!(
+            "uniform int EDGE_MODE <\n",
+            "    ui_tooltip = \"Luma: shading and texture edges as well; the classic DLAA mask.\\n\"\n",
+            "                 \"Geometric: silhouettes only, ignores flat UI.\";\n",
+            "    > = 0;\n",
+            "/*--------------.\n",
+            "| :: IMPORTS :: |\n",
+            "'--------------*/\n",
+            "namespace Kernel {}\n",
+            "namespace LumeniteTRAA {\n",
+            "    confidence = saturate(confidence + 0.11 * 4.0 * confidence * (1.0 - confidence));\n",
+            "\n",
+            "    float2 historyUV = texcoord + flow;\n",
+            "technique Lumenite_TRAA <\n",
+            "    ui_tooltip = \"Temporal Reprojection Anti-Aliasing.\";\n",
+            ">\n",
+            "}\n",
+        );
+        let dest = shaders.join("lumenite_TRAA.fx");
+        fs::write(&dest, body).unwrap();
+        let first = apply_traa_ui_patch(t.path()).unwrap().unwrap();
+        assert!(first.contains("UI protect patch"), "{first}");
+        let text = fs::read_to_string(&dest).unwrap();
+        assert!(text.contains("DLSS5_TRAA_UI_PROTECT"));
+        assert!(text.contains("UI_PROTECT"));
+        assert!(text.contains("> = 1;"));
+        let second = apply_traa_ui_patch(t.path()).unwrap().unwrap();
+        assert!(second.contains("already applied"), "{second}");
+    }
+
 
     #[test]
     fn single_from_zip_and_uninstall() {
@@ -1977,11 +2853,12 @@ RestoreComputeSignature=true
     }
 
     #[test]
-    fn uninstall_all_removes_reshade_only_when_nothing_foreign_remains() {
+    fn uninstall_all_removes_reshade_even_with_leftover_shaders() {
         let t = tempfile::tempdir().unwrap();
         let d = t.path();
         let exe = make_pe(&d.join("game.exe"), game::PE_X64);
         crate::game::testutil::make_reshade_dll(&d.join("dxgi.dll"));
+        fs::write(d.join(game::RESHADE_MARKER), b"6.8.0").unwrap();
         let sh = d.join("reshade-shaders").join("Shaders");
         fs::create_dir_all(&sh).unwrap();
         fs::write(d.join(game::FEEDER_ADDON), b"x").unwrap();
@@ -1990,20 +2867,41 @@ RestoreComputeSignature=true
         fs::write(d.join("ReShade.ini"), b"x").unwrap();
         fs::write(d.join("ReShadePreset.ini"), b"x").unwrap();
         fs::write(d.join("dlss5-feed.cfg"), b"x").unwrap();
-        // a foreign shader blocks ReShade removal
+        // Pre-existing shader pack (Gothic 3 etc.) must not block dxgi.dll removal.
         fs::write(sh.join("Clarity.fx"), b"user shader").unwrap();
-        let (_removed, kept) = uninstall_all(&exe).unwrap();
-        assert!(kept.is_some());
-        assert!(d.join("dxgi.dll").is_file());
+        // dgVoodoo for DX9 games must never be touched.
+        fs::write(d.join("d3d9.dll"), b"MZ...dgVoodoo2 wrapper...").unwrap();
+        fs::write(d.join("dgVoodoo.conf"), b"[DirectX]\nOutputAPI = bestavailable\n").unwrap();
+
+        let (removed, kept) = uninstall_all(&exe).unwrap();
+        assert!(kept.is_none(), "{kept:?}");
+        assert!(removed.iter().any(|r| r == "dxgi.dll"));
+        assert!(!d.join("dxgi.dll").exists());
+        assert!(!d.join(game::RESHADE_MARKER).exists());
+        assert!(!d.join("ReShade.ini").exists());
+        assert!(!d.join("dlss5-feed.cfg").exists());
         assert!(!d.join(game::FEEDER_ADDON).is_file());
-        // without it, everything goes
-        fs::remove_file(sh.join("Clarity.fx")).unwrap();
+        assert!(d.join("reshade-shaders").join("Shaders").join("Clarity.fx").is_file());
+        assert!(d.join("d3d9.dll").is_file(), "dgVoodoo d3d9.dll must stay");
+        assert!(d.join("dgVoodoo.conf").is_file());
+        assert!(!game::inspect(&exe).unwrap().reshade);
+    }
+
+    #[test]
+    fn uninstall_all_cleans_empty_reshade_shaders_tree() {
+        let t = tempfile::tempdir().unwrap();
+        let d = t.path();
+        let exe = make_pe(&d.join("game.exe"), game::PE_X64);
+        crate::game::testutil::make_reshade_dll(&d.join("dxgi.dll"));
+        let sh = d.join("reshade-shaders").join("Shaders");
+        fs::create_dir_all(&sh).unwrap();
+        fs::write(sh.join("ReShade.fxh"), b"x").unwrap();
+        fs::write(d.join("ReShade.ini"), b"x").unwrap();
         let (removed, kept) = uninstall_all(&exe).unwrap();
         assert!(kept.is_none(), "{kept:?}");
         assert!(removed.iter().any(|r| r == "dxgi.dll"));
         assert!(!d.join("dxgi.dll").exists());
         assert!(!d.join("ReShade.ini").exists());
-        assert!(!d.join("dlss5-feed.cfg").exists());
         assert!(!d.join("reshade-shaders").exists());
     }
 
@@ -2056,6 +2954,10 @@ RestoreComputeSignature=true
             Engine::ReShade,
             false,
             true,
+            InstallOpts {
+                quality: QualityChoice::Auto,
+                overrides: QualityOverrides::default(),
+            },
             &|_, _| {},
             &|_, _, _, _, _| {},
         )
@@ -2090,6 +2992,10 @@ RestoreComputeSignature=true
             Engine::Opti,
             false,
             false,
+            InstallOpts {
+                quality: QualityChoice::Auto,
+                overrides: QualityOverrides::default(),
+            },
             &|_, _| {},
             &|_, _, _, _, _| {},
         )
@@ -2127,6 +3033,10 @@ RestoreComputeSignature=true
             Engine::Opti,
             false,
             false,
+            InstallOpts {
+                quality: QualityChoice::Auto,
+                overrides: QualityOverrides::default(),
+            },
             &|_, _| {},
             &|_, _, _, _, _| {},
         )

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -93,8 +93,8 @@ fn apply_traa_ui_patch(game_dir: &Path) -> Result<Option<String>> {
     if !dest.is_file() {
         return Ok(None);
     }
-    let mut text = fs::read_to_string(&dest)
-        .with_context(|| format!("reading {}", dest.display()))?;
+    let mut text =
+        fs::read_to_string(&dest).with_context(|| format!("reading {}", dest.display()))?;
     if text.contains(TRAA_UI_MARKER) {
         return Ok(Some(format!(
             "reshade-shaders/Shaders/{TRAA_FX} (UI protect, already applied)"
@@ -317,7 +317,6 @@ impl Latest {
         }
     }
 }
-
 
 /// Files that must exist after a successful Feeder/Native install.
 /// Used so the UI never says "Everything is in place" on a partial copy.
@@ -1139,7 +1138,9 @@ fn merge_dgvoodoo_conf(existing: &str) -> String {
                 vram_set = true;
                 continue;
             }
-            if section.eq_ignore_ascii_case("DirectX") && key.eq_ignore_ascii_case("dgVoodooWatermark") {
+            if section.eq_ignore_ascii_case("DirectX")
+                && key.eq_ignore_ascii_case("dgVoodooWatermark")
+            {
                 out.push_str("dgVoodooWatermark = false\n");
                 watermark_set = true;
                 continue;
@@ -1222,9 +1223,7 @@ fn assert_dgvoodoo_conf_healthy(text: &str) -> Result<()> {
         }
     }
     if !vram_ok {
-        bail!(
-            "dgVoodoo.conf health check failed: VRAM must be >= {DGVOODOO_VRAM_FLOOR}"
-        );
+        bail!("dgVoodoo.conf health check failed: VRAM must be >= {DGVOODOO_VRAM_FLOOR}");
     }
     Ok(())
 }
@@ -1235,11 +1234,10 @@ pub fn write_dgvoodoo_conf(game_dir: &Path) -> Result<()> {
     let conf = game_dir.join("dgVoodoo.conf");
     let bak = game_dir.join("dgVoodoo.conf.bak");
     let text = if conf.is_file() {
-        let existing = fs::read_to_string(&conf)
-            .with_context(|| format!("reading {}", conf.display()))?;
+        let existing =
+            fs::read_to_string(&conf).with_context(|| format!("reading {}", conf.display()))?;
         if !bak.is_file() {
-            fs::write(&bak, &existing)
-                .with_context(|| format!("writing {}", bak.display()))?;
+            fs::write(&bak, &existing).with_context(|| format!("writing {}", bak.display()))?;
         }
         merge_dgvoodoo_conf(&existing)
     } else {
@@ -1273,10 +1271,8 @@ pub fn install_dgvoodoo_from_zip(
         .find(|n| {
             let norm = n.replace('\\', "/");
             norm.eq_ignore_ascii_case(want)
-                || (bitness != 64
-                    && norm.to_ascii_lowercase().ends_with("/ms/x86/d3d9.dll"))
-                || (bitness == 64
-                    && norm.to_ascii_lowercase().ends_with("/ms/x64/d3d9.dll"))
+                || (bitness != 64 && norm.to_ascii_lowercase().ends_with("/ms/x86/d3d9.dll"))
+                || (bitness == 64 && norm.to_ascii_lowercase().ends_with("/ms/x64/d3d9.dll"))
         })
         .map(str::to_owned)
         .ok_or_else(|| {
@@ -2222,9 +2218,7 @@ pub fn uninstall_all(exe: &Path) -> Result<(Vec<String>, Option<String>)> {
     }
     if shaders_root.is_dir() {
         if leftover_shaders {
-            removed.push(
-                "reshade-shaders/ (left: shaders this tool did not install)".into(),
-            );
+            removed.push("reshade-shaders/ (left: shaders this tool did not install)".into());
         } else {
             fs::remove_dir_all(&shaders_root)?;
             removed.push("reshade-shaders/".into());
@@ -2296,10 +2290,7 @@ mod tests {
         let z = t.path().join("feeder.zip");
         write_zip(
             &z,
-            &[
-                (game::FEEDER_ADDON, b"addon"),
-                (game::FEEDER_FX, b"fx"),
-            ],
+            &[(game::FEEDER_ADDON, b"addon"), (game::FEEDER_FX, b"fx")],
             &[],
         );
         let out = copy_vulkan_feeder_kit_from_zip(&z, d, "v0.14.0").unwrap();
@@ -2549,7 +2540,6 @@ mod tests {
         let second = apply_traa_ui_patch(t.path()).unwrap().unwrap();
         assert!(second.contains("already applied"), "{second}");
     }
-
 
     #[test]
     fn single_from_zip_and_uninstall() {
@@ -2871,7 +2861,11 @@ RestoreComputeSignature=true
         fs::write(sh.join("Clarity.fx"), b"user shader").unwrap();
         // dgVoodoo for DX9 games must never be touched.
         fs::write(d.join("d3d9.dll"), b"MZ...dgVoodoo2 wrapper...").unwrap();
-        fs::write(d.join("dgVoodoo.conf"), b"[DirectX]\nOutputAPI = bestavailable\n").unwrap();
+        fs::write(
+            d.join("dgVoodoo.conf"),
+            b"[DirectX]\nOutputAPI = bestavailable\n",
+        )
+        .unwrap();
 
         let (removed, kept) = uninstall_all(&exe).unwrap();
         assert!(kept.is_none(), "{kept:?}");
@@ -2881,7 +2875,11 @@ RestoreComputeSignature=true
         assert!(!d.join("ReShade.ini").exists());
         assert!(!d.join("dlss5-feed.cfg").exists());
         assert!(!d.join(game::FEEDER_ADDON).is_file());
-        assert!(d.join("reshade-shaders").join("Shaders").join("Clarity.fx").is_file());
+        assert!(d
+            .join("reshade-shaders")
+            .join("Shaders")
+            .join("Clarity.fx")
+            .is_file());
         assert!(d.join("d3d9.dll").is_file(), "dgVoodoo d3d9.dll must stay");
         assert!(d.join("dgVoodoo.conf").is_file());
         assert!(!game::inspect(&exe).unwrap().reshade);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod diagnose;
+mod feeder_cfg;
 mod game;
 mod gpu;
 mod gpupref;
@@ -10,8 +11,10 @@ mod library;
 mod logo;
 mod net;
 mod ngx;
+mod quality_preset;
 mod renodx;
 mod reshade_ini;
+mod settings;
 mod text;
 mod theme;
 mod update;
@@ -422,7 +425,19 @@ fn cli(
             Error => println!("\n      FAILED: {detail}"),
         }
     };
-    match installer::run_all_with(&exe, engine, with_renodx, upstream, &progress, &step) {
+    let s = settings::Settings::load();
+    match installer::run_all_with(
+        &exe,
+        engine,
+        with_renodx,
+        upstream,
+        installer::InstallOpts {
+            quality: s.quality_choice(),
+            overrides: s.quality_overrides(),
+        },
+        &progress,
+        &step,
+    ) {
         Ok(_) => {
             if engine == installer::Engine::Opti {
                 println!(

--- a/src/quality_preset.rs
+++ b/src/quality_preset.rs
@@ -150,7 +150,8 @@ fn base_medium() -> ResolvedQuality {
         lighting_strength: 1.35,
         detail_threshold: 0.018,
         detail_strength: 1.40,
-        summary: "Medium: engine velocity hunt + Lumenite fallback, residual masks, work 85% + FSR".into(),
+        summary: "Medium: engine velocity hunt + Lumenite fallback, residual masks, work 85% + FSR"
+            .into(),
     }
 }
 
@@ -180,7 +181,8 @@ fn base_high() -> ResolvedQuality {
         lighting_strength: 1.50,
         detail_threshold: 0.012,
         detail_strength: 1.55,
-        summary: "High: engine velocity + Optical Flow fallback, stronger masks, full resolution".into(),
+        summary: "High: engine velocity + Optical Flow fallback, stronger masks, full resolution"
+            .into(),
     }
 }
 
@@ -372,15 +374,9 @@ pub fn feed_fx_uniforms(r: &ResolvedQuality) -> Vec<(&'static str, String)> {
             "LIGHTING_MASK",
             if r.lighting_mask { "1" } else { "0" }.into(),
         ),
-        (
-            "LIGHTING_THRESHOLD",
-            format!("{:.3}", r.lighting_threshold),
-        ),
+        ("LIGHTING_THRESHOLD", format!("{:.3}", r.lighting_threshold)),
         ("LIGHTING_STRENGTH", format!("{:.2}", r.lighting_strength)),
-        (
-            "DETAIL_MASK",
-            if r.detail_mask { "1" } else { "0" }.into(),
-        ),
+        ("DETAIL_MASK", if r.detail_mask { "1" } else { "0" }.into()),
         ("DETAIL_THRESHOLD", format!("{:.3}", r.detail_threshold)),
         ("DETAIL_STRENGTH", format!("{:.2}", r.detail_strength)),
     ]

--- a/src/quality_preset.rs
+++ b/src/quality_preset.rs
@@ -1,0 +1,488 @@
+//! Quality presets for Feeder installs: Auto / Low / Medium / High.
+//!
+//! Used only to write a sensible default `dlss5-feed.cfg` + FX uniforms at Install.
+//! Live knobs live in the ReShade overlay (Feeder), not in the oneclick GUI.
+//! Feeder auto-profile then retunes reset / lightstab / OFA once from observed game data.
+
+use crate::game::{Api, GameStatus, Mode};
+use crate::gpu::{self, Tier};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QualityChoice {
+    Auto,
+    Low,
+    Medium,
+    High,
+}
+
+impl QualityChoice {
+    pub fn label(self) -> &'static str {
+        match self {
+            QualityChoice::Auto => "Auto",
+            QualityChoice::Low => "Low",
+            QualityChoice::Medium => "Medium",
+            QualityChoice::High => "High",
+        }
+    }
+
+    pub fn cfg_name(self) -> &'static str {
+        match self {
+            QualityChoice::Auto => "auto",
+            QualityChoice::Low => "low",
+            QualityChoice::Medium => "medium",
+            QualityChoice::High => "high",
+        }
+    }
+}
+
+/// Optional Advanced overrides from the GUI (applied on top of the chosen preset).
+#[derive(Debug, Clone, Default)]
+pub struct QualityOverrides {
+    pub ofa_enabled: Option<bool>,
+    pub ofa_grid: Option<i32>,
+    pub work_resolution: Option<i32>,
+    pub work_upscale: Option<i32>,
+    pub appearance_mask: Option<bool>,
+    pub lighting_mask: Option<bool>,
+    pub detail_mask: Option<bool>,
+    pub appearance_threshold: Option<f32>,
+    pub lighting_threshold: Option<f32>,
+    pub detail_threshold: Option<f32>,
+}
+
+impl QualityOverrides {
+    pub fn any_set(&self) -> bool {
+        self.ofa_enabled.is_some()
+            || self.ofa_grid.is_some()
+            || self.work_resolution.is_some()
+            || self.work_upscale.is_some()
+            || self.appearance_mask.is_some()
+            || self.lighting_mask.is_some()
+            || self.detail_mask.is_some()
+            || self.appearance_threshold.is_some()
+            || self.lighting_threshold.is_some()
+            || self.detail_threshold.is_some()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedQuality {
+    pub choice: QualityChoice,
+    /// True when Advanced overrides changed something vs the base preset.
+    pub customized: bool,
+    pub ofa_enabled: bool,
+    pub ofa_grid: i32,
+    pub ofa_perf: i32,
+    pub work_resolution: i32,
+    pub work_upscale: i32,
+    pub work_sharpness: f32,
+    pub engine_velocity: bool,
+    /// Enable Lumenite_Kernel technique in ReShadePreset (false when OFA supplies MV).
+    pub enable_lumenite: bool,
+    pub appearance_mask: bool,
+    pub lighting_mask: bool,
+    pub detail_mask: bool,
+    pub appearance_threshold: f32,
+    pub appearance_strength: f32,
+    pub lighting_threshold: f32,
+    pub lighting_strength: f32,
+    pub detail_threshold: f32,
+    pub detail_strength: f32,
+    pub summary: String,
+}
+
+fn nvidia_ofa_capable(st: &GameStatus) -> bool {
+    let tier = st
+        .gpu
+        .as_ref()
+        .map(|(_, t)| *t)
+        .or_else(|| gpu::best().map(|(_, t)| t));
+    match tier {
+        Some(Tier::Rtx50 | Tier::Rtx40 | Tier::Rtx2030) => true,
+        Some(Tier::Unknown) => true, // named NVIDIA without clear RTX digits
+        _ => false,
+    }
+}
+
+fn base_low() -> ResolvedQuality {
+    ResolvedQuality {
+        choice: QualityChoice::Low,
+        customized: false,
+        ofa_enabled: false,
+        ofa_grid: 2,
+        ofa_perf: 10,
+        work_resolution: 70,
+        work_upscale: 1,
+        work_sharpness: 0.35,
+        engine_velocity: false,
+        enable_lumenite: true,
+        appearance_mask: true,
+        lighting_mask: true,
+        detail_mask: true,
+        appearance_threshold: 0.050,
+        appearance_strength: 1.0,
+        lighting_threshold: 0.060,
+        lighting_strength: 1.0,
+        detail_threshold: 0.028,
+        detail_strength: 1.0,
+        summary: "Low: Lumenite MV, softer masks, work 70% + FSR expand".into(),
+    }
+}
+
+fn base_medium() -> ResolvedQuality {
+    ResolvedQuality {
+        choice: QualityChoice::Medium,
+        customized: false,
+        ofa_enabled: false,
+        ofa_grid: 2,
+        ofa_perf: 10,
+        work_resolution: 85,
+        work_upscale: 1,
+        work_sharpness: 0.30,
+        engine_velocity: true,
+        enable_lumenite: true,
+        appearance_mask: true,
+        lighting_mask: true,
+        detail_mask: true,
+        appearance_threshold: 0.035,
+        appearance_strength: 1.25,
+        lighting_threshold: 0.040,
+        lighting_strength: 1.35,
+        detail_threshold: 0.018,
+        detail_strength: 1.40,
+        summary: "Medium: engine velocity hunt + Lumenite fallback, residual masks, work 85% + FSR".into(),
+    }
+}
+
+/// Safe default when no install context is set (tests / unexpected path).
+pub fn fallback_medium() -> ResolvedQuality {
+    base_medium()
+}
+
+fn base_high() -> ResolvedQuality {
+    ResolvedQuality {
+        choice: QualityChoice::High,
+        customized: false,
+        ofa_enabled: true,
+        ofa_grid: 1,
+        ofa_perf: 10,
+        work_resolution: 100,
+        work_upscale: 0,
+        work_sharpness: 0.30,
+        engine_velocity: true,
+        enable_lumenite: false,
+        appearance_mask: true,
+        lighting_mask: true,
+        detail_mask: true,
+        appearance_threshold: 0.025,
+        appearance_strength: 1.40,
+        lighting_threshold: 0.030,
+        lighting_strength: 1.50,
+        detail_threshold: 0.012,
+        detail_strength: 1.55,
+        summary: "High: engine velocity + Optical Flow fallback, stronger masks, full resolution".into(),
+    }
+}
+
+fn apply_overrides(mut r: ResolvedQuality, o: &QualityOverrides) -> ResolvedQuality {
+    if !o.any_set() {
+        return r;
+    }
+    r.customized = true;
+    if let Some(v) = o.ofa_enabled {
+        r.ofa_enabled = v;
+        r.enable_lumenite = !v;
+    }
+    if let Some(v) = o.ofa_grid {
+        r.ofa_grid = v;
+    }
+    if let Some(v) = o.work_resolution {
+        r.work_resolution = v.clamp(50, 100);
+    }
+    if let Some(v) = o.work_upscale {
+        r.work_upscale = v.clamp(0, 2);
+    }
+    if let Some(v) = o.appearance_mask {
+        r.appearance_mask = v;
+    }
+    if let Some(v) = o.lighting_mask {
+        r.lighting_mask = v;
+    }
+    if let Some(v) = o.detail_mask {
+        r.detail_mask = v;
+    }
+    if let Some(v) = o.appearance_threshold {
+        r.appearance_threshold = v;
+    }
+    if let Some(v) = o.lighting_threshold {
+        r.lighting_threshold = v;
+    }
+    if let Some(v) = o.detail_threshold {
+        r.detail_threshold = v;
+    }
+    r.summary = format!("{} (customized)", r.choice.label());
+    r
+}
+
+/// Resolve a quality choice for this game / machine.
+pub fn resolve(
+    choice: QualityChoice,
+    st: &GameStatus,
+    overrides: &QualityOverrides,
+) -> ResolvedQuality {
+    let ofa_ok = st.mode == Mode::Feeder
+        && matches!(st.api, Api::Dx11)
+        && !st.is32()
+        && st.anticheat.is_none()
+        && nvidia_ofa_capable(st);
+
+    let base = match choice {
+        QualityChoice::Low => base_low(),
+        QualityChoice::Medium => base_medium(),
+        QualityChoice::High => {
+            let mut h = base_high();
+            if !ofa_ok {
+                // High without OFA: keep aggressive masks + velocity hunt, fall back to Lumenite.
+                h.ofa_enabled = false;
+                h.enable_lumenite = true;
+                h.engine_velocity = true;
+                h.summary =
+                    "High: engine velocity + Lumenite (Optical Flow unavailable), stronger masks, full res"
+                        .into();
+            }
+            h
+        }
+        QualityChoice::Auto => {
+            if ofa_ok {
+                let mut a = base_high();
+                a.choice = QualityChoice::Auto;
+                a.ofa_grid = 2; // Auto uses default grid, not High's 1px
+                a.engine_velocity = true;
+                a.appearance_threshold = 0.030;
+                a.lighting_threshold = 0.035;
+                a.detail_threshold = 0.015;
+                a.summary =
+                    "Auto: engine velocity + Optical Flow + residual masks (Feeder D3D11 + RTX) — recommendation only"
+                        .into();
+                a
+            } else if matches!(st.api, Api::Dx12) {
+                let mut a = base_medium();
+                a.choice = QualityChoice::Auto;
+                a.ofa_enabled = false;
+                a.enable_lumenite = true;
+                a.engine_velocity = true;
+                a.work_resolution = 100;
+                a.summary =
+                    "Auto: DX12 Feeder (no OFA) — Lumenite MV + velocity hunt; Optimize uses half-rate cost first"
+                        .into();
+                a
+            } else {
+                let mut a = base_medium();
+                a.choice = QualityChoice::Auto;
+                a.engine_velocity = true;
+                a.summary =
+                    "Auto: Medium + engine velocity hunt (Optical Flow not applicable) — recommendation only"
+                        .into();
+                a
+            }
+        }
+    };
+
+    let mut r = apply_overrides(base, overrides);
+    // RT-likely titles: slightly cheaper seed + stronger light stab (flicker proxy).
+    if st.mode == Mode::Feeder && st.rt_likely && !r.customized {
+        r.work_resolution = r.work_resolution.min(90);
+        r.summary = format!("{} · RT-likely seed (work≤90%)", r.summary);
+    }
+    r
+}
+
+/// Full `dlss5-feed.cfg` text matching Feeder's CfgSave layout (defaults for untouched keys).
+/// `auto_profile_applied=0` so the add-on auto-tunes once on first attach from live game data.
+pub fn feeder_cfg_text(r: &ResolvedQuality) -> String {
+    format!(
+        "enabled=1\n\
+         mode=2\n\
+         hdr=-1\n\
+         depth_inverted=-1\n\
+         flags=-1\n\
+         reset_every=0\n\
+         warmup_rebuild=180\n\
+         rebuild=0\n\
+         log_frames=3\n\
+         create_delay=60\n\
+         preset=0\n\
+         work_resolution={}\n\
+         work_upscale={}\n\
+         work_sharpness={:.2}\n\
+         gpu_timeout_ms=2000\n\
+         buffer_home=1\n\
+         async_home=0\n\
+         sync_home=0\n\
+         mv_scale_x=1.000\n\
+         mv_scale_y=1.000\n\
+         stall_log_ms=50\n\
+         reset_mode=2\n\
+         log_detail=1\n\
+         log_detail_every=60\n\
+         light_stab=0\n\
+         light_stab_strength=0.350\n\
+         light_stab_max_delta=0.060\n\
+         ofa_enabled={}\n\
+         ofa_grid={}\n\
+         ofa_perf={}\n\
+         engine_velocity={}\n\
+         velocity_cand=-1\n\
+         velocity_decode=0\n\
+         velocity_scale=1.000\n\
+         quality_preset={}\n\
+         auto_profile_applied=0\n\
+         auto_profile=\n",
+        r.work_resolution,
+        r.work_upscale,
+        r.work_sharpness,
+        if r.ofa_enabled { 1 } else { 0 },
+        r.ofa_grid,
+        r.ofa_perf,
+        if r.engine_velocity { 1 } else { 0 },
+        if r.customized {
+            "custom"
+        } else {
+            r.choice.cfg_name()
+        },
+    )
+}
+
+/// Uniform keys for `[DLSS5_Feed.fx]` in ReShadePreset.ini.
+pub fn feed_fx_uniforms(r: &ResolvedQuality) -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "APPEARANCE_MASK",
+            if r.appearance_mask { "1" } else { "0" }.into(),
+        ),
+        (
+            "APPEARANCE_THRESHOLD",
+            format!("{:.3}", r.appearance_threshold),
+        ),
+        (
+            "APPEARANCE_STRENGTH",
+            format!("{:.2}", r.appearance_strength),
+        ),
+        (
+            "LIGHTING_MASK",
+            if r.lighting_mask { "1" } else { "0" }.into(),
+        ),
+        (
+            "LIGHTING_THRESHOLD",
+            format!("{:.3}", r.lighting_threshold),
+        ),
+        ("LIGHTING_STRENGTH", format!("{:.2}", r.lighting_strength)),
+        (
+            "DETAIL_MASK",
+            if r.detail_mask { "1" } else { "0" }.into(),
+        ),
+        ("DETAIL_THRESHOLD", format!("{:.3}", r.detail_threshold)),
+        ("DETAIL_STRENGTH", format!("{:.2}", r.detail_strength)),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::{Api, Mode};
+    use std::path::PathBuf;
+
+    fn stub_status(mode: Mode, api: Api) -> GameStatus {
+        GameStatus {
+            mode,
+            api,
+            bridge: false,
+            opti: false,
+            gpu: Some((
+                crate::gpu::Gpu {
+                    name: "NVIDIA GeForce RTX 4060".into(),
+                    vendor: "NVIDIA".into(),
+                },
+                Tier::Rtx40,
+            )),
+            exe: PathBuf::from(r"C:\g\game.exe"),
+            bitness: 64,
+            reshade: false,
+            headers: false,
+            feeder: false,
+            lumenite: false,
+            dlss5_addon: false,
+            dlssnr: false,
+            dlss: false,
+            mode_detected: mode,
+            host_exe: false,
+            host_reshade: false,
+            re_engine: false,
+            reframework: false,
+            upstream: false,
+            unreal_likely: false,
+            unity_likely: false,
+            rt_likely: false,
+            renodx_mod: None,
+            foreign_renodx: vec![],
+            anticheat: None,
+            problems: vec![],
+        }
+    }
+
+    #[test]
+    fn auto_d3d11_rtx_enables_ofa() {
+        let st = stub_status(Mode::Feeder, Api::Dx11);
+        let r = resolve(QualityChoice::Auto, &st, &QualityOverrides::default());
+        assert!(r.ofa_enabled);
+        assert!(!r.enable_lumenite);
+    }
+
+    #[test]
+    fn auto_dx12_falls_back_medium() {
+        let st = stub_status(Mode::Feeder, Api::Dx12);
+        let r = resolve(QualityChoice::Auto, &st, &QualityOverrides::default());
+        assert!(!r.ofa_enabled);
+        assert!(r.enable_lumenite);
+        assert_eq!(r.work_resolution, 100);
+        assert!(r.summary.contains("DX12"));
+    }
+
+    #[test]
+    fn medium_baseline_keys() {
+        let r = base_medium();
+        assert!(!r.ofa_enabled);
+        assert!(r.enable_lumenite);
+        assert!(r.engine_velocity);
+        assert_eq!(r.work_resolution, 85);
+        let cfg = feeder_cfg_text(&r);
+        assert!(cfg.contains("ofa_enabled=0"));
+        assert!(cfg.contains("engine_velocity=1"));
+        assert!(cfg.contains("work_resolution=85"));
+        assert!(cfg.contains("quality_preset=medium"));
+        assert!(cfg.contains("auto_profile_applied=0"));
+    }
+
+    #[test]
+    fn high_aggressive_masks() {
+        let r = base_high();
+        assert!(r.ofa_enabled);
+        assert!(!r.enable_lumenite);
+        assert!(r.engine_velocity);
+        assert!(r.appearance_threshold < base_medium().appearance_threshold);
+        let fx = feed_fx_uniforms(&r);
+        assert!(fx.iter().any(|(k, v)| *k == "DETAIL_MASK" && v == "1"));
+    }
+
+    #[test]
+    fn overrides_mark_custom() {
+        let o = QualityOverrides {
+            work_resolution: Some(90),
+            ..Default::default()
+        };
+        let r = apply_overrides(base_medium(), &o);
+        assert!(r.customized);
+        assert_eq!(r.work_resolution, 90);
+        assert!(feeder_cfg_text(&r).contains("quality_preset=custom"));
+    }
+}

--- a/src/reshade_ini.rs
+++ b/src/reshade_ini.rs
@@ -11,11 +11,10 @@ use anyhow::Result;
 use std::fs;
 use std::path::Path;
 
-pub const MV_PROVIDER_DEFINE: &str = "DLSS5_MV_PROVIDER=3"; // LumeniteFX Kernel
-pub const TECHNIQUES_ORDERED: [&str; 2] = [
-    "Lumenite_Kernel@lumenite_Kernel.fx", // provider must sit ABOVE the feed
-    "DLSS5_Feed@DLSS5_Feed.fx",
-];
+pub const MV_PROVIDER_DEFINE: &str = "DLSS5_MV_PROVIDER=3"; // LumeniteFX Kernel (also used when OFA replaces MV at runtime)
+pub const TECHNIQUE_LUMENITE: &str = "Lumenite_Kernel@lumenite_Kernel.fx";
+pub const TECHNIQUE_FEED: &str = "DLSS5_Feed@DLSS5_Feed.fx";
+pub const TECHNIQUES_ORDERED: [&str; 2] = [TECHNIQUE_LUMENITE, TECHNIQUE_FEED];
 
 /// Ordered sections; the first is always the root ("").
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -157,19 +156,60 @@ fn ensure_define(raw: &str, define: &str) -> String {
     join_list(&items)
 }
 
+/// ReShade recursive glob is a single trailing `\**`. A doubled `\**\**` (common after
+/// ReShade's path UI rewrites our default) fails Win32 resolve with ERROR_INVALID_NAME
+/// (123) and the overlay reports "No effect files (.fx) found".
+fn normalize_search_path(raw: &str) -> String {
+    let mut s = raw.trim().replace('/', "\\");
+    while s.contains(r"**\**") {
+        s = s.replace(r"**\**", "**");
+    }
+    s
+}
+
+fn path_key(p: &str) -> String {
+    normalize_search_path(p).trim_end_matches(['\\', '/']).to_ascii_lowercase()
+}
+
+/// Collapse broken `\**\**` globs and ensure `required` is present (prepended if missing).
+fn ensure_search_paths(raw: &str, required: &str) -> String {
+    let required = normalize_search_path(required);
+    let req_key = path_key(&required);
+    let mut items: Vec<String> = split_list(raw)
+        .into_iter()
+        .map(|p| normalize_search_path(&p))
+        .filter(|p| !p.is_empty())
+        .collect();
+    if !items.iter().any(|p| path_key(p) == req_key) {
+        items.insert(0, required);
+    }
+    join_list(&items)
+}
+
+pub const EFFECT_SEARCH_PATH: &str = r".\reshade-shaders\Shaders\**";
+pub const TEXTURE_SEARCH_PATH: &str = r".\reshade-shaders\Textures\**";
+
 /// Create/update ReShade.ini: search paths + PresetPath defaults, provider define forced.
 pub fn write_reshade_ini(game_dir: &Path) -> Result<()> {
     let p = game_dir.join("ReShade.ini");
     let mut ini = Ini::load(&p);
-    ini.set_default(
+    // Always rewrite search paths: set_default left broken `\**\**` values from ReShade
+    // alone, which makes Install look successful while the overlay finds zero .fx files.
+    ini.set(
         "GENERAL",
         "EffectSearchPaths",
-        r".\reshade-shaders\Shaders\**",
+        ensure_search_paths(
+            ini.get("GENERAL", "EffectSearchPaths").unwrap_or(""),
+            EFFECT_SEARCH_PATH,
+        ),
     );
-    ini.set_default(
+    ini.set(
         "GENERAL",
         "TextureSearchPaths",
-        r".\reshade-shaders\Textures\**",
+        ensure_search_paths(
+            ini.get("GENERAL", "TextureSearchPaths").unwrap_or(""),
+            TEXTURE_SEARCH_PATH,
+        ),
     );
     ini.set_default("GENERAL", "PresetPath", r".\ReShadePreset.ini");
     let defs = ensure_define(
@@ -180,12 +220,18 @@ pub fn write_reshade_ini(game_dir: &Path) -> Result<()> {
     ini.save(&p)
 }
 
-/// Create/update ReShadePreset.ini: Lumenite_Kernel then DLSS5_Feed at the head of
-/// the enabled list (existing user techniques kept after), provider define at preset level.
-pub fn write_preset(game_dir: &Path) -> Result<()> {
+/// Create/update ReShadePreset.ini. When `enable_lumenite` is false (Optical Flow preset),
+/// only DLSS5_Feed is enabled; Lumenite files may still be on disk as fallback.
+pub fn write_preset(game_dir: &Path, enable_lumenite: bool) -> Result<()> {
     let p = game_dir.join("ReShadePreset.ini");
     let mut ini = Ini::load(&p);
-    let ours: Vec<String> = TECHNIQUES_ORDERED.iter().map(|s| s.to_string()).collect();
+    let ours: Vec<String> = if enable_lumenite {
+        TECHNIQUES_ORDERED.iter().map(|s| s.to_string()).collect()
+    } else {
+        vec![TECHNIQUE_FEED.to_string()]
+    };
+    // Drop both of our techniques from the existing list, then prepend the desired set.
+    let drop: &[&str] = &TECHNIQUES_ORDERED;
     for key in ["Techniques", "TechniqueSorting"] {
         if key == "TechniqueSorting" && ini.get("", key).is_none() {
             continue;
@@ -194,7 +240,7 @@ pub fn write_preset(game_dir: &Path) -> Result<()> {
         list.extend(
             split_list(ini.get("", key).unwrap_or(""))
                 .into_iter()
-                .filter(|t| !ours.contains(t)),
+                .filter(|t| !drop.iter().any(|d| d == t)),
         );
         ini.set("", key, join_list(&list));
     }
@@ -203,6 +249,32 @@ pub fn write_preset(game_dir: &Path) -> Result<()> {
         MV_PROVIDER_DEFINE,
     );
     ini.set("", "PreprocessorDefinitions", defs);
+    ini.save(&p)
+}
+
+/// Write residual-mask uniforms into `[DLSS5_Feed.fx]`.
+pub fn write_feed_fx_uniforms(game_dir: &Path, kv: &[(&str, String)]) -> Result<()> {
+    let p = game_dir.join("ReShadePreset.ini");
+    let mut ini = Ini::load(&p);
+    for (k, v) in kv {
+        ini.set("DLSS5_Feed.fx", k, v.clone());
+    }
+    ini.save(&p)
+}
+
+/// Soft defaults for optional LUMENITE: TRAA (does not enable the technique).
+/// Geometric DLAA + UI protect reduce HUD/text smear when the user turns TRAA on.
+pub fn write_traa_ui_defaults(game_dir: &Path) -> Result<()> {
+    let p = game_dir.join("ReShadePreset.ini");
+    if !p.is_file() {
+        return Ok(());
+    }
+    let mut ini = Ini::load(&p);
+    let section = "lumenite_TRAA.fx";
+    ini.set_default(section, "EDGE_MODE", "1");
+    ini.set_default(section, "UI_PROTECT", "1");
+    ini.set_default(section, "UI_PROTECT_STRENGTH", "1.000000");
+    ini.set_default(section, "SHARP_STRENGTH", "0.700000");
     ini.save(&p)
 }
 
@@ -278,11 +350,11 @@ mod tests {
         let ini = Ini::load(&t.path().join("ReShade.ini"));
         assert_eq!(
             ini.get("GENERAL", "EffectSearchPaths"),
-            Some(r".\reshade-shaders\Shaders\**")
+            Some(EFFECT_SEARCH_PATH)
         );
         assert_eq!(
             ini.get("GENERAL", "TextureSearchPaths"),
-            Some(r".\reshade-shaders\Textures\**")
+            Some(TEXTURE_SEARCH_PATH)
         );
         assert_eq!(
             ini.get("GENERAL", "PresetPath"),
@@ -305,8 +377,8 @@ mod tests {
         write_reshade_ini(t.path()).unwrap();
         let ini = Ini::load(&t.path().join("ReShade.ini"));
         assert_eq!(
-            ini.get("GENERAL", "EffectSearchPaths"),
-            Some(".\\custom\\**")
+            split_list(ini.get("GENERAL", "EffectSearchPaths").unwrap()),
+            vec![EFFECT_SEARCH_PATH, r".\custom\**"]
         );
         assert_eq!(
             split_list(ini.get("GENERAL", "PreprocessorDefinitions").unwrap()),
@@ -316,9 +388,29 @@ mod tests {
     }
 
     #[test]
+    fn reshade_ini_collapses_doubled_recursive_glob() {
+        let t = tempfile::tempdir().unwrap();
+        fs::write(
+            t.path().join("ReShade.ini"),
+            "[GENERAL]\nEffectSearchPaths=.\\reshade-shaders\\Shaders\\**\\**\nTextureSearchPaths=.\\reshade-shaders\\Textures\\**\\**\n",
+        )
+        .unwrap();
+        write_reshade_ini(t.path()).unwrap();
+        let ini = Ini::load(&t.path().join("ReShade.ini"));
+        assert_eq!(
+            ini.get("GENERAL", "EffectSearchPaths"),
+            Some(EFFECT_SEARCH_PATH)
+        );
+        assert_eq!(
+            ini.get("GENERAL", "TextureSearchPaths"),
+            Some(TEXTURE_SEARCH_PATH)
+        );
+    }
+
+    #[test]
     fn remove_our_techniques_keeps_user_ones() {
         let t = tempfile::tempdir().unwrap();
-        write_preset(t.path()).unwrap();
+        write_preset(t.path(), true).unwrap();
         let p = t.path().join("ReShadePreset.ini");
         let mut ini = Ini::load(&p);
         ini.set(
@@ -337,7 +429,7 @@ mod tests {
     #[test]
     fn preset_fresh() {
         let t = tempfile::tempdir().unwrap();
-        write_preset(t.path()).unwrap();
+        write_preset(t.path(), true).unwrap();
         let ini = Ini::load(&t.path().join("ReShadePreset.ini"));
         assert_eq!(
             split_list(ini.get("", "Techniques").unwrap()),
@@ -358,7 +450,7 @@ mod tests {
             "Techniques=DLSS5_Feed@DLSS5_Feed.fx,Clarity@Clarity.fx\nTechniqueSorting=Clarity@Clarity.fx,DLSS5_Feed@DLSS5_Feed.fx\n[Clarity.fx]\nStrength=0.5\n",
         )
         .unwrap();
-        write_preset(t.path()).unwrap();
+        write_preset(t.path(), true).unwrap();
         let ini = Ini::load(&t.path().join("ReShadePreset.ini"));
         assert_eq!(
             split_list(ini.get("", "Techniques").unwrap()),
@@ -377,6 +469,25 @@ mod tests {
         assert!(
             text.starts_with("Techniques="),
             "root keys must precede sections: {text}"
+        );
+    }
+
+    #[test]
+    fn traa_ui_defaults_are_soft() {
+        let t = tempfile::tempdir().unwrap();
+        fs::write(
+            t.path().join("ReShadePreset.ini"),
+            "Techniques=DLSS5_Feed@DLSS5_Feed.fx\n[lumenite_TRAA.fx]\nEDGE_MODE=0\nSHARP_STRENGTH=1.000000\n",
+        )
+        .unwrap();
+        write_traa_ui_defaults(t.path()).unwrap();
+        let ini = Ini::load(&t.path().join("ReShadePreset.ini"));
+        // Existing EDGE_MODE kept; missing UI_PROTECT filled in.
+        assert_eq!(ini.get("lumenite_TRAA.fx", "EDGE_MODE"), Some("0"));
+        assert_eq!(ini.get("lumenite_TRAA.fx", "UI_PROTECT"), Some("1"));
+        assert_eq!(
+            ini.get("lumenite_TRAA.fx", "SHARP_STRENGTH"),
+            Some("1.000000")
         );
     }
 }

--- a/src/reshade_ini.rs
+++ b/src/reshade_ini.rs
@@ -168,7 +168,9 @@ fn normalize_search_path(raw: &str) -> String {
 }
 
 fn path_key(p: &str) -> String {
-    normalize_search_path(p).trim_end_matches(['\\', '/']).to_ascii_lowercase()
+    normalize_search_path(p)
+        .trim_end_matches(['\\', '/'])
+        .to_ascii_lowercase()
 }
 
 /// Collapse broken `\**\**` globs and ensure `required` is present (prepended if missing).

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,10 @@
 //! Global app settings: `%LOCALAPPDATA%\dlss5oneclick\settings.json`.
 //!
-//! Applied on new Install (and optionally "Apply defaults to this game").
+//! These are **user install defaults**: saved here and applied on new Install
+//! (and optionally "Apply defaults to this game"). They are distinct from
+//! **Feeder built-in defaults** (`CfgWriteDefault` / static `g_cfg` in
+//! DLSS5-Feeder) — use [`Settings::feeder_stock`] / the Settings UI
+//! "Reset to Feeder defaults" button to restore the form to Feeder-like values.
 
 use crate::quality_preset::{QualityChoice, QualityOverrides};
 use anyhow::{Context, Result};
@@ -83,6 +87,48 @@ impl Default for Settings {
 }
 
 impl Settings {
+    /// Feeder stock values (`dlss5-feed.cpp` `g_cfg` + OFA/velocity/lightstab/diag headers).
+    ///
+    /// Typical stock cfg / UI:
+    /// - `quality` seed = Auto (oneclick only; Feeder has no quality seed file)
+    /// - `work_resolution` = 100
+    /// - `ofa_enabled` = off, `ofa_grid` = 2, `ofa_perf` = 10
+    /// - `reset_mode` = 2 (adaptive), `light_stab` = off, `engine_velocity` = on
+    /// - overlay: `log_detail` = 1, `evaluate_stride` = 1, `log_frames` = 3
+    ///
+    /// Residual FX mask toggles/thresholds stay unset (`None`) so Install still
+    /// follows the quality preset for those axes.
+    pub fn feeder_stock() -> Self {
+        Self {
+            quality: default_quality(),
+            knobs: KnobDefaults {
+                work_resolution: Some(100),
+                ofa_enabled: Some(false),
+                ofa_grid: Some(2),
+                ofa_perf: Some(10),
+                reset_mode: Some(2),
+                light_stab: Some(false),
+                engine_velocity: Some(true),
+                appearance_mask: None,
+                lighting_mask: None,
+                detail_mask: None,
+                appearance_threshold: None,
+                lighting_threshold: None,
+                detail_threshold: None,
+            },
+            overlay: OverlayDefaults {
+                log_detail: 1,
+                evaluate_stride: 1,
+                log_frames: 3,
+            },
+        }
+    }
+
+    /// Restore knobs / overlay / quality seed to [`Self::feeder_stock`].
+    pub fn reset_to_feeder_defaults(&mut self) {
+        *self = Self::feeder_stock();
+    }
+
     pub fn path() -> PathBuf {
         dirs_local_appdata()
             .unwrap_or_else(|| PathBuf::from("."))
@@ -101,8 +147,7 @@ impl Settings {
     pub fn save(&self) -> Result<()> {
         let p = Self::path();
         if let Some(parent) = p.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("create {}", parent.display()))?;
+            fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
         }
         let t = serde_json::to_string_pretty(self)?;
         fs::write(&p, t).with_context(|| format!("write {}", p.display()))?;
@@ -147,17 +192,20 @@ pub fn apply_overlay_to_cfg(cfg: &str, s: &Settings) -> String {
     let mut lines: Vec<String> = cfg.lines().map(|l| l.to_string()).collect();
     let mut set = |key: &str, value: String| {
         let prefix = format!("{key}=");
-        if let Some(i) = lines
-            .iter()
-            .position(|l| l.to_ascii_lowercase().starts_with(&prefix.to_ascii_lowercase()))
-        {
+        if let Some(i) = lines.iter().position(|l| {
+            l.to_ascii_lowercase()
+                .starts_with(&prefix.to_ascii_lowercase())
+        }) {
             lines[i] = format!("{key}={value}");
         } else {
             lines.push(format!("{key}={value}"));
         }
     };
     set("log_detail", s.overlay.log_detail.to_string());
-    set("evaluate_stride", s.overlay.evaluate_stride.clamp(1, 4).to_string());
+    set(
+        "evaluate_stride",
+        s.overlay.evaluate_stride.clamp(1, 4).to_string(),
+    );
     set("log_frames", s.overlay.log_frames.to_string());
     if let Some(v) = s.knobs.reset_mode {
         set("reset_mode", v.to_string());
@@ -191,6 +239,33 @@ mod tests {
         let back: Settings = serde_json::from_str(&t).unwrap();
         assert_eq!(back.quality, "auto");
         assert_eq!(back.overlay.evaluate_stride, 1);
+    }
+
+    #[test]
+    fn feeder_stock_matches_documented_knobs() {
+        let s = Settings::feeder_stock();
+        assert_eq!(s.quality_choice(), QualityChoice::Auto);
+        assert_eq!(s.knobs.work_resolution, Some(100));
+        assert_eq!(s.knobs.ofa_enabled, Some(false));
+        assert_eq!(s.knobs.ofa_grid, Some(2));
+        assert_eq!(s.knobs.ofa_perf, Some(10));
+        assert_eq!(s.knobs.reset_mode, Some(2));
+        assert_eq!(s.knobs.light_stab, Some(false));
+        assert_eq!(s.knobs.engine_velocity, Some(true));
+        assert_eq!(s.overlay.log_detail, 1);
+        assert_eq!(s.overlay.evaluate_stride, 1);
+        assert_eq!(s.overlay.log_frames, 3);
+        let mut other = Settings {
+            quality: "high".into(),
+            knobs: KnobDefaults {
+                work_resolution: Some(70),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        other.reset_to_feeder_defaults();
+        assert_eq!(other.knobs.work_resolution, Some(100));
+        assert_eq!(other.quality, "auto");
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,206 @@
+//! Global app settings: `%LOCALAPPDATA%\dlss5oneclick\settings.json`.
+//!
+//! Applied on new Install (and optionally "Apply defaults to this game").
+
+use crate::quality_preset::{QualityChoice, QualityOverrides};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Settings {
+    /// Seed quality for Feeder installs.
+    #[serde(default = "default_quality")]
+    pub quality: String,
+    /// Feeder overlay / cfg defaults written on Install.
+    #[serde(default)]
+    pub knobs: KnobDefaults,
+    /// Soft overlay UX defaults (cfg keys the Feeder reads).
+    #[serde(default)]
+    pub overlay: OverlayDefaults,
+}
+
+fn default_quality() -> String {
+    "auto".into()
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct KnobDefaults {
+    pub work_resolution: Option<i32>,
+    pub ofa_enabled: Option<bool>,
+    pub ofa_grid: Option<i32>,
+    pub ofa_perf: Option<i32>,
+    pub reset_mode: Option<i32>,
+    pub light_stab: Option<bool>,
+    pub engine_velocity: Option<bool>,
+    pub appearance_mask: Option<bool>,
+    pub lighting_mask: Option<bool>,
+    pub detail_mask: Option<bool>,
+    pub appearance_threshold: Option<f32>,
+    pub lighting_threshold: Option<f32>,
+    pub detail_threshold: Option<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OverlayDefaults {
+    #[serde(default = "default_log_detail")]
+    pub log_detail: i32,
+    #[serde(default = "default_evaluate_stride")]
+    pub evaluate_stride: i32,
+    #[serde(default = "default_log_frames")]
+    pub log_frames: i32,
+}
+
+fn default_log_detail() -> i32 {
+    1
+}
+fn default_evaluate_stride() -> i32 {
+    1
+}
+fn default_log_frames() -> i32 {
+    3
+}
+
+impl Default for OverlayDefaults {
+    fn default() -> Self {
+        Self {
+            log_detail: default_log_detail(),
+            evaluate_stride: default_evaluate_stride(),
+            log_frames: default_log_frames(),
+        }
+    }
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            quality: default_quality(),
+            knobs: KnobDefaults::default(),
+            overlay: OverlayDefaults::default(),
+        }
+    }
+}
+
+impl Settings {
+    pub fn path() -> PathBuf {
+        dirs_local_appdata()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("dlss5oneclick")
+            .join("settings.json")
+    }
+
+    pub fn load() -> Self {
+        let p = Self::path();
+        match fs::read_to_string(&p) {
+            Ok(t) => serde_json::from_str(&t).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let p = Self::path();
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        let t = serde_json::to_string_pretty(self)?;
+        fs::write(&p, t).with_context(|| format!("write {}", p.display()))?;
+        Ok(())
+    }
+
+    pub fn quality_choice(&self) -> QualityChoice {
+        match self.quality.to_ascii_lowercase().as_str() {
+            "low" => QualityChoice::Low,
+            "medium" | "med" => QualityChoice::Medium,
+            "high" => QualityChoice::High,
+            _ => QualityChoice::Auto,
+        }
+    }
+
+    pub fn set_quality_choice(&mut self, c: QualityChoice) {
+        self.quality = c.cfg_name().to_owned();
+    }
+
+    pub fn quality_overrides(&self) -> QualityOverrides {
+        QualityOverrides {
+            ofa_enabled: self.knobs.ofa_enabled,
+            ofa_grid: self.knobs.ofa_grid,
+            work_resolution: self.knobs.work_resolution,
+            work_upscale: None,
+            appearance_mask: self.knobs.appearance_mask,
+            lighting_mask: self.knobs.lighting_mask,
+            detail_mask: self.knobs.detail_mask,
+            appearance_threshold: self.knobs.appearance_threshold,
+            lighting_threshold: self.knobs.lighting_threshold,
+            detail_threshold: self.knobs.detail_threshold,
+        }
+    }
+}
+
+fn dirs_local_appdata() -> Option<PathBuf> {
+    std::env::var_os("LOCALAPPDATA").map(PathBuf::from)
+}
+
+/// Patch cfg text with overlay UX defaults from settings (log_detail, evaluate_stride, …).
+pub fn apply_overlay_to_cfg(cfg: &str, s: &Settings) -> String {
+    let mut lines: Vec<String> = cfg.lines().map(|l| l.to_string()).collect();
+    let mut set = |key: &str, value: String| {
+        let prefix = format!("{key}=");
+        if let Some(i) = lines
+            .iter()
+            .position(|l| l.to_ascii_lowercase().starts_with(&prefix.to_ascii_lowercase()))
+        {
+            lines[i] = format!("{key}={value}");
+        } else {
+            lines.push(format!("{key}={value}"));
+        }
+    };
+    set("log_detail", s.overlay.log_detail.to_string());
+    set("evaluate_stride", s.overlay.evaluate_stride.clamp(1, 4).to_string());
+    set("log_frames", s.overlay.log_frames.to_string());
+    if let Some(v) = s.knobs.reset_mode {
+        set("reset_mode", v.to_string());
+        set("reset_every", if v == 1 { "1" } else { "0" }.into());
+    }
+    if let Some(v) = s.knobs.light_stab {
+        set("light_stab", (v as i32).to_string());
+    }
+    if let Some(v) = s.knobs.engine_velocity {
+        set("engine_velocity", (v as i32).to_string());
+    }
+    if let Some(v) = s.knobs.ofa_perf {
+        set("ofa_perf", v.to_string());
+    }
+    let mut out = lines.join("\n");
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_defaults() {
+        let s = Settings::default();
+        assert_eq!(s.quality_choice(), QualityChoice::Auto);
+        let t = serde_json::to_string(&s).unwrap();
+        let back: Settings = serde_json::from_str(&t).unwrap();
+        assert_eq!(back.quality, "auto");
+        assert_eq!(back.overlay.evaluate_stride, 1);
+    }
+
+    #[test]
+    fn overlay_patch_inserts_keys() {
+        let mut s = Settings::default();
+        s.overlay.log_detail = 2;
+        s.overlay.evaluate_stride = 2;
+        let out = apply_overlay_to_cfg("enabled=1\nwork_resolution=100\n", &s);
+        assert!(out.contains("log_detail=2"));
+        assert!(out.contains("evaluate_stride=2"));
+        assert!(out.contains("work_resolution=100"));
+    }
+}


### PR DESCRIPTION
## Summary
- Follow-up to closed #55 after your packaging review: **no** `assets/patches` Feeder overwrite — official [DLSS5-Feeder](https://github.com/jlrouzies-fr/DLSS5-Feeder) release zip only.
- Feeder-side Optimize / mask / OFA / perf-writer work: [jlrouzies-fr/DLSS5-Feeder#76](https://github.com/jlrouzies-fr/DLSS5-Feeder/pull/76).
- `settings.rs` + `feeder_cfg.rs` + `quality_preset.rs`: Settings page seeds quality/cfg defaults on Install; offline `dlss5-feed.cfg` + FX uniforms editor on Setup.
- Post-install verifies dxgi/ReShade, Feeder addon/FX, headers (and Feeder stack files); refuses a hollow success. First-run tip + collapsible install log (failures sorted to the top).
- Version left at main (`0.11.24`). `cargo clippy --all-targets -- -D warnings` clean.

## Test plan
- [ ] Settings Save → new Install writes cfg / overlay defaults
- [ ] Offline knobs Write cfg on an installed game
- [ ] Incomplete folder is not reported as fully ready
- [ ] First-run tip dismisses and stays dismissed
- [ ] Ko-fi button unchanged
- [ ] `cargo clippy --all-targets -- -D warnings`
